### PR TITLE
Numpyro version of fit_villar

### DIFF
--- a/analysis/fit_villar.py
+++ b/analysis/fit_villar.py
@@ -359,6 +359,11 @@ def plot_posterior_draws(sn, lc_path='', out_path='', save_fig=True):
                 color = color_dict[pb], ls='--', lw=0.6, alpha=0.3)
     
         ax.set_xlabel('Time (JD - 2018 Jan 01)',fontsize=14)
+        x_max = np.min([pi_max_t0 + pi_max_gamma + 10*pi_max_tfall, 
+                   np.max(lc_df_thisfilt.jd.values) - jd0 + 10])
+        ax.set_xlim(pi_max_t0 - 75, x_max)
+        ax.set_ylim(-3*median_abs_deviation(lc_df_thisfilt.fnu_microJy.values), 
+                    1.2*np.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))
         ax.set_ylabel(r'Flux ($\mu$Jy)',fontsize=14)
         ax.tick_params(axis='both', which='major', labelsize=12)
         fig.subplots_adjust(left=0.8,bottom=0.13,right=0.99, top=0.99)

--- a/analysis/fit_villar.py
+++ b/analysis/fit_villar.py
@@ -114,11 +114,15 @@ def load_lc_df(sn, lc_path, min_num_obs=10):
     lc_path : string (optional, default = '')
         File path to folder containing processed fps lc files from Miller+24
 
+    min_num_obs : int (optional, default = 10)
+        If there are fewer than min_num_obs observations for any given filter,
+        exclude from output dataframe
+
     Returns
     -------
     lc_df_clean : pandas dataframe
         Dataframe of LC obs. with flags==0 and valid flux measurements. Entire 
-        passbands may be excluded if there were fewer than 10 valid points
+        passbands may be excluded if there were fewer than min_num_obs valid points
     '''
 
     lc_df = pd.read_csv(f"{lc_path}/{sn}_fnu.csv")

--- a/analysis/fit_villar.py
+++ b/analysis/fit_villar.py
@@ -239,7 +239,8 @@ def fit_gr(sn, lc_path='', out_path=''):
             Y_obs = pm.Normal('Y_obs', mu=mu_switch, 
                               sigma=Y_unc, observed=Y_observed)
             # Draw samples from the posterior
-            data = pm.sample(1000, tune = 15000, cores = 4, 
+            data = pm.sample(1000, tune = 15000, cores = 4,
+                             discard_tuned_samples=False,
                              return_inferencedata=True, 
                              progressbar = True, 
                              target_accept=0.99)
@@ -370,7 +371,7 @@ def plot_posterior_draws(sn, lc_path='', out_path='', save_fig=True):
                     1.2*np.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))
         ax.set_ylabel(r'Flux ($\mu$Jy)',fontsize=14)
         ax.tick_params(axis='both', which='major', labelsize=12)
-        fig.subplots_adjust(left=0.8,bottom=0.13,right=0.99, top=0.99)
+        #fig.subplots_adjust(left=0.8,bottom=0.13,right=0.99, top=0.99)
     if save_fig:
         fig.savefig(f"{lc_path}/{sn}_posterior.png", 
                     dpi = 600, transparent=True)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -102,7 +102,9 @@ def load_lc_df(sn, lc_path, min_num_obs=10):
             continue
         else:
             keep_ind.append(pb_lc[0])
-
+    if len(keep_ind) == 0:
+        print(f"{sn} has 0 data points passing quality cuts; skipping this source")
+    
     lc_df_clean = lc_df.iloc[np.concatenate(keep_ind)]
     return lc_df_clean
 
@@ -478,7 +480,6 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
         x_max = np.min([pi_max_t0 + pi_max_gamma + 10 * pi_max_tfall,
                         np.max(lc_df_thisfilt.jd.values) - jd0 + 10])
         if filt != 'i': ## make sure to NOT set axis limits based on i-band
-        
             ax.set_xlim(pi_max_t0 - 75, x_max)
             ax.set_ylim(-3 * median_abs_deviation(lc_df_thisfilt.fnu_microJy.values),
                         1.2 * np.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -134,7 +134,9 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
         loc=Amp_Guess,
         scale=Amp_Guess / 10, low=0))
 
-    Beta = numpyro.sample("Beta", dist.Uniform(low=-jnp.max(Y_observed_val) / 150, high=0))
+    #Beta = numpyro.sample("Beta", dist.Uniform(low=-jnp.max(Y_observed_val) / 150, high=0))
+    uniformbeta_low = -jnp.max(Y_observed_val) / 150
+    Beta = numpyro.sample("Beta", dist.Normal(0, uniformbeta_low * (-0.3)))
 
     t0 = numpyro.sample("t0", dist.Uniform(
         low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -368,8 +368,8 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
 
         ax.set_xlabel('Time (JD - 2018 Jan 01)', fontsize=14)
         # xlim may be unstable, since we're picking a random posterior instead of the max. prob. posterior
-        x_max = jnp.min([pi_t0[0] + pi_gamma[0] + 10 * pi_tfall[0],
-                        jnp.max(lc_df_thisfilt.jd.values) - jd0 + 10])
+        x_max = np.min([pi_t0[0] + pi_gamma[0] + 10 * pi_tfall[0],
+                        np.max(lc_df_thisfilt.jd.values) - jd0 + 10])
         ax.set_xlim(pi_t0[0] - 75, x_max)
         ax.set_ylim(-3 * median_abs_deviation(lc_df_thisfilt.fnu_microJy.values),
                     1.2 * jnp.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -217,9 +217,15 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
             num_samples=num_samples,
             num_chains=num_chains,
             progress_bar=True)
+        sampler.warmup(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
+        warmup_samples = sampler.get_samples()
+        np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
 
         # Draw samples from the posterior
         sampler.run(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed)
+        samples = sampler.get_samples()
+        np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
+
         # Save results
         data = az.from_numpyro(sampler)
         data.to_netcdf(f"{out_path}/{sn}_{filt}_numpyro.nc")

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -126,7 +126,7 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     """
 
     # Define priors based on Villar+19
-    trise = numpyro.sample("trise", dist.Uniform(low=1e-4, high=60)) #0.01, high=50))  # dist.continuous.Uniform?
+    trise = numpyro.sample("trise", dist.Uniform(low=0.01, high=50))  # dist.continuous.Uniform?
     tfall = numpyro.sample("tfall", dist.Uniform(low=1, high=300))
 
     Amp_Guess = jnp.max(Y_observed_val)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -484,13 +484,8 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
         # save axis limits based on this filter
         xlims.append((pi_max_t0 - 75, x_max))
         ylims.append((-3 * median_abs_deviation(lc_df_thisfilt.fnu_microJy.values),
-                        1.2 * np.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5)))
+                        1.5 * np.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5)))
 
-    # choose largest axis lims between all filters
-    #choose_x = np.argmax([pair[1]-pair[0] for pair in xlims])
-    #choose_y = np.argmax([pair[1]-pair[0] for pair in ylims])
-    #ax.set_xlim(xlims[choose_x][0], xlims[choose_x][1])
-    #ax.set_ylim(ylims[choose_y][0], ylims[choose_y][1])
     # choose min and max of all lims
     ax.set_xlim(np.min([i[0] for i in xlims]), np.max([i[1] for i in xlims]))
     ax.set_ylim(np.min([i[0] for i in ylims]), np.max([i[1] for i in ylims]))

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -5,6 +5,7 @@ from numpyro import distributions as dist, infer
 import matplotlib.pyplot as plt
 import numpy as np
 import arviz as az
+import pandas as pd
 
 from scipy.stats import median_abs_deviation
 
@@ -177,7 +178,6 @@ def plot_posterior_draws_numpyro(sampler, sn, lc_path=''):
             color=color_dict[pb], ls='--', lw=0.6, alpha=0.3)
 
     ax.set_xlabel('Time (JD - 2018 Jan 01)', fontsize=14)
-    ax.set_xlim(20, 600)
     ax.set_ylim(-3 * median_abs_deviation(lc_df_thisfilt.fnu_microJy.values),
                 1.2 * jnp.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))
     ax.set_ylabel(r'Flux ($\mu$Jy)', fontsize=14)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -7,8 +7,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import arviz as az
 import pandas as pd
-
 from scipy.stats import median_abs_deviation
+
+import argparse
 
 
 def calc_sn_exp_both(t, A, B, t0, gamma, trise, tfall, offset):
@@ -330,7 +331,7 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
         jd0 = 2458119.5  # 2018 Jan 01
 
         try:
-            chains = az.from_netcdf(f"{out_path}/{sn}_{filt}.nc")
+            chains = az.from_netcdf(f"{out_path}/{sn}_{filt}_numpyro.nc")
         except:
             print(f'Unable to find chains for {sn} in {pb}, skipping this filter.')
             continue
@@ -378,3 +379,31 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
         if save_fig:
             fig.savefig(f"{lc_path}/{sn}_posterior_numpyro.png",
                         dpi=600, transparent=True)
+
+def main():
+
+    # Initialize argument parser
+    parser = argparse.ArgumentParser(prog='fit_villar_numpyro.py <sn>',
+                                     description='Run Villar+19 light curve fits on a BTS fps lc. with numpyro')
+    # Necessary arguments
+    parser.add_argument('sn', type=str, nargs='?', default=None,
+                   help='ZTF transient name')
+    # Optional arguments
+    parser.add_argument('lc_path', type=str, nargs='?', default=None,
+                   help='path to folder containing processed fps lc file from Miller+24')
+    parser.add_argument('out_path', type=str, nargs='?', default=None,
+                   help='path for output MCMC chains')
+
+
+    try:
+        args = parser.parse_args()
+
+        run = True
+    except Exception:
+        run = False
+
+    if run:
+        fit_gr(**vars(args))
+
+if __name__ == "__main__":
+    main()

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -101,8 +101,61 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
                    dist.Normal(mu_switch, Y_unc_val),
                    obs=Y_observed_val)
 
+def lc_model_hier_oneSN(t_val, Y_unc_val, Y_observed_val=None):# find a way to add this -> within numpyro model structure hier_vars=[]):
+    # sampling...
+    # Define priors based on Villar+19
+    # x_grid = jnp.logspace(-3, np.log10(60), 500)
+    # logistic_pdf = lambda x, tau, x0: 1/(1 + jnp.exp(-(x - x0)/tau))
+    # pm.Interpolated('trise', x_grid,
+    #                logistic_pdf(x_grid, 5e-3, 0.1))
+    #if 'trise' in hier_vars:
+    trise_low = numpyro.sample("trise_low", dist.Uniform(low=5e-3, high=0.02))
+    trise_high = numpyro.sample("trise_high", dist.Uniform(low=45, high=55))
+    trise = numpyro.sample("trise", dist.Uniform(low=trise_low, high=trise_high)) #0.01,50 # dist.continuous.Uniform?
+    #else:
+    #    trise = numpyro.sample("trise", dist.Uniform(low=0.01, high=50))
 
-def plot_posterior_draws_numpyro(sampler, sn, lc_path=''):
+    tfall_low = numpyro.sample("tfall_low", dist.Uniform(low=0.5, high=1.5))
+    tfall_high = numpyro.sample("tfall_high", dist.Uniform(low=295, high=305))
+    tfall = numpyro.sample("tfall", dist.Uniform(low=tfall_low, high=tfall_high))
+
+
+    Amp_Guess = jnp.max(Y_observed_val)
+    Amp_mu = numpyro.sample("Amp_mu", dist.Uniform(low=Amp_Guess-500, high=Amp_Guess+500))
+    #Amp_sigma = numpyro.sample("Amp_sigma", dist.Uniform(low=Amp_Guess/11, high=Amp_Guess/9))
+    Amplitude = numpyro.sample("Amplitude", dist.TruncatedNormal(
+        loc=Amp_mu,
+        scale=Amp_Guess / 10, low=0))
+        #loc=Amp_Guess,
+        #scale=Amp_Guess / 10, low=0))
+
+    Beta = numpyro.sample("Beta", dist.Uniform(low=-jnp.max(Y_observed_val) / 150, high=0))
+
+    t0 = numpyro.sample("t0", dist.Uniform(
+        low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
+        high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
+
+    sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
+    scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,
+                                                           low=-2 * sigma_est,
+                                                           high=2 * sigma_est))
+
+    mixing_dist = dist.Categorical(probs=jnp.array([2 / 3, 1 / 3]))
+    component_dist = dist.Normal(loc=jnp.array([5, 60]), scale=jnp.array([5, 30]))
+    gamma = numpyro.sample("gamma", dist.MixtureSameFamily(mixing_distribution=mixing_dist,
+                                                           component_distribution=component_dist))
+
+    # Expected value of outcome
+    mu_switch = calc_sn_exp_both(t_val, Amplitude, Beta, t0, gamma, trise, tfall, scalar)
+
+    # Sample!
+    # with numpyro.plate("data", len(t_val)):
+    numpyro.sample("y",
+                   dist.Normal(mu_switch, Y_unc_val),
+                   obs=Y_observed_val)
+
+
+def plot_posterior_draws_numpyro(filt_sampler_pairs, sn, lc_path=''):
     """
     Plot posterior draws of model from Villar+19 to ZTF light curve
 
@@ -123,63 +176,65 @@ def plot_posterior_draws_numpyro(sampler, sn, lc_path=''):
 
     lc_df = load_lc_df(sn, lc_path)
     fig, ax = plt.subplots(figsize=(10, 4))
-    # TODO: return to multi-filter
-    pb = lc_df.passband.unique()[0]  # r band
-    # for pb in lc_df.passband.unique():
-    filt = pb[-1]
-    lc_df_thisfilt = lc_df[(lc_df["passband"] == f'ZTF_{filt}')]
+    for pair in filt_sampler_pairs:
+        filt, sampler = pair
+        pb = 'ZTF_'+filt
 
-    jd0 = 2458119.5  # 2018 Jan 01
+        lc_df_thisfilt = lc_df[(lc_df["passband"] == f'ZTF_{filt}')]
 
-    try:
-        chains = az.from_numpyro(sampler)  # az.from_netcdf(f"{out_path}/{sn}_{filt}.nc")
-    except:
-        print(f'Unable to find chains for {sn} in {pb}, skipping this filter.')
-    ax.errorbar(lc_df_thisfilt.jd.values - jd0,
-                lc_df_thisfilt.fnu_microJy.values,
-                lc_df_thisfilt.fnu_microJy_unc.values,
-                fmt='o', color=color_dict[pb])
+        jd0 = 2458119.5  # 2018 Jan 01
 
-    # posterior samples
-    n_samples = len(chains.posterior.t0.values.flatten())
-    rand_idx = np.random.choice(range(n_samples),
-                                90, replace=False)
-    pi_t0 = chains.posterior.t0.values.flatten()[rand_idx]
-    pi_amp = chains.posterior.Amplitude.values.flatten()[rand_idx]
-    pi_beta = chains.posterior.Beta.values.flatten()[rand_idx]
-    pi_gamma = chains.posterior.gamma.values.flatten()[rand_idx]
-    pi_trise = chains.posterior.trise.values.flatten()[rand_idx]
-    pi_tfall = chains.posterior.tfall.values.flatten()[rand_idx]
-    pi_scalar = chains.posterior.scalar.values.flatten()[rand_idx]
+        try:
+            chains = az.from_numpyro(sampler)  # az.from_netcdf(f"{out_path}/{sn}_{filt}.nc")
+        except:
+            print(f'Unable to find chains for {sn} in {pb}, skipping this filter.')
+        ax.errorbar(lc_df_thisfilt.jd.values - jd0,
+                    lc_df_thisfilt.fnu_microJy.values,
+                    lc_df_thisfilt.fnu_microJy_unc.values,
+                    fmt='o', color=color_dict[pb])
 
-    t_grid_rise = jnp.linspace(pi_t0 - 150,
-                               pi_t0 + pi_gamma,
-                               num=10000)
-    ax.plot(t_grid_rise,
-            calc_sn_exp_rise(t_grid_rise,
-                             pi_amp,
-                             pi_beta,
-                             pi_t0,
-                             pi_trise,
-                             pi_scalar),
-            color=color_dict[pb], ls='--', lw=0.6, alpha=0.3)
-    t_grid_decline = jnp.linspace(pi_t0 + pi_gamma,
-                                  jnp.max(lc_df_thisfilt.jd.values) - jd0,
-                                  num=10000)
-    ax.plot(t_grid_decline,
-            calc_sn_exp_decline(t_grid_decline,
-                                pi_amp,
-                                pi_beta,
-                                pi_t0,
-                                pi_gamma,
-                                pi_trise,
-                                pi_tfall,
-                                pi_scalar),
-            color=color_dict[pb], ls='--', lw=0.6, alpha=0.3)
+        # posterior samples
+        n_samples = len(chains.posterior.t0.values.flatten())
+        rand_idx = np.random.choice(range(n_samples),
+                                    90, replace=False)
+        pi_t0 = chains.posterior.t0.values.flatten()[rand_idx]
+        pi_amp = chains.posterior.Amplitude.values.flatten()[rand_idx]
+        pi_beta = chains.posterior.Beta.values.flatten()[rand_idx]
+        pi_gamma = chains.posterior.gamma.values.flatten()[rand_idx]
+        pi_trise = chains.posterior.trise.values.flatten()[rand_idx]
+        pi_tfall = chains.posterior.tfall.values.flatten()[rand_idx]
+        pi_scalar = chains.posterior.scalar.values.flatten()[rand_idx]
 
-    ax.set_xlabel('Time (JD - 2018 Jan 01)', fontsize=14)
-    ax.set_ylim(-3 * median_abs_deviation(lc_df_thisfilt.fnu_microJy.values),
-                1.2 * jnp.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))
-    ax.set_ylabel(r'Flux ($\mu$Jy)', fontsize=14)
-    ax.tick_params(axis='both', which='major', labelsize=12)
-    fig.subplots_adjust(left=0.8, bottom=0.13, right=0.99, top=0.99)
+        t_grid_rise = jnp.linspace(pi_t0 - 150,
+                                   pi_t0 + pi_gamma,
+                                   num=10000)
+        ax.plot(t_grid_rise,
+                calc_sn_exp_both(t_grid_rise,
+                                 pi_amp,
+                                 pi_beta,
+                                 pi_t0,
+                                 pi_gamma,
+                                 pi_trise,
+                                 pi_tfall,
+                                 pi_scalar),
+                color=color_dict[pb], ls='--', lw=0.6, alpha=0.3)
+        t_grid_decline = jnp.linspace(pi_t0 + pi_gamma,
+                                      jnp.max(lc_df_thisfilt.jd.values) - jd0,
+                                      num=10000)
+        ax.plot(t_grid_decline,
+                calc_sn_exp_both(t_grid_decline,
+                                 pi_amp,
+                                 pi_beta,
+                                 pi_t0,
+                                 pi_gamma,
+                                 pi_trise,
+                                 pi_tfall,
+                                 pi_scalar),
+                color=color_dict[pb], ls='--', lw=0.6, alpha=0.3)
+
+        ax.set_xlabel('Time (JD - 2018 Jan 01)', fontsize=14)
+        ax.set_ylim(-3 * median_abs_deviation(lc_df_thisfilt.fnu_microJy.values),
+                    1.2 * jnp.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))
+        ax.set_ylabel(r'Flux ($\mu$Jy)', fontsize=14)
+        ax.tick_params(axis='both', which='major', labelsize=12)
+        fig.subplots_adjust(left=0.8, bottom=0.13, right=0.99, top=0.99)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -1,0 +1,185 @@
+import jax.numpy as jnp
+import numpyro
+from numpyro import distributions as dist, infer
+
+import matplotlib.pyplot as plt
+import numpy as np
+import arviz as az
+
+from scipy.stats import median_abs_deviation
+
+
+def load_lc_df(sn, lc_path, min_num_obs=10):
+    """
+    Load ZTF light curve (LC) into a dataframe, with quality cuts
+
+    Parameters
+    ----------
+    sn : string
+        ZTF name of the SN to be fit by the model
+
+    lc_path : string (optional, default = '')
+        File path to folder containing processed fps lc files from Miller+24
+
+    Returns
+    -------
+    lc_df_clean : pandas dataframe
+        Dataframe of LC obs. with flags==0 and valid flux measurements. Entire
+        passbands may be excluded if there were fewer than 10 valid points
+    """
+
+    lc_df = pd.read_csv(f"{lc_path}/{sn}_fnu.csv")
+
+    keep_ind = []
+
+    for pb in lc_df.passband.unique():
+
+        pb_lc = np.where((lc_df["passband"] == pb) &
+                         (lc_df["flags"] == 0) &
+                         # # CHECK IF THIS IS WHAT SHOULD BE DONE!!!
+                         # (lc_df["programid"] == 1) &
+                         (lc_df["fnu_microJy"] != -999)
+                         )
+        if len(pb_lc[0]) < min_num_obs:
+            # if fewer than min_num_obs pts in this filter, don't include in df
+            continue
+        else:
+            keep_ind.append(pb_lc[0])
+
+    lc_df_clean = lc_df.iloc[np.concatenate(keep_ind)]
+    return lc_df_clean
+
+
+def calc_sn_exp_both(t, A, B, t0, gamma, trise, tfall, offset):
+    f = jnp.where(gamma + t0 >= t,
+                  ((A + B * (t - t0)) / (1 + jnp.exp(-(t - t0) / trise))) + offset,
+                  offset + ((A + B * gamma) *
+                            jnp.exp(-(t - (gamma + t0)) / tfall) /
+                            (1 + jnp.exp(-(t - t0) / trise))))
+    return f
+
+
+def lc_model(t_val, Y_unc_val, Y_observed_val=None):
+    # sampling...
+    # Define priors based on Villar+19
+    # x_grid = jnp.logspace(-3, np.log10(60), 500)
+    # logistic_pdf = lambda x, tau, x0: 1/(1 + jnp.exp(-(x - x0)/tau))
+    trise = numpyro.sample("trise", dist.Uniform(low=0.01, high=50))  # dist.continuous.Uniform?
+    # pm.Interpolated('trise', x_grid,
+    #                logistic_pdf(x_grid, 5e-3, 0.1))
+
+    tfall = numpyro.sample("tfall", dist.Uniform(low=1, high=300))
+
+    Amp_Guess = jnp.max(Y_observed_val)
+    Amplitude = numpyro.sample("Amplitude", dist.TruncatedNormal(
+        loc=Amp_Guess,
+        scale=Amp_Guess / 10, low=0))
+
+    Beta = numpyro.sample("Beta", dist.Uniform(low=-jnp.max(Y_observed_val) / 150, high=0))
+
+    t0 = numpyro.sample("t0", dist.Uniform(
+        low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
+        high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
+
+    sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
+    scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,
+                                                           low=-2 * sigma_est,
+                                                           high=2 * sigma_est))
+
+    mixing_dist = dist.Categorical(probs=jnp.array([2 / 3, 1 / 3]))
+    component_dist = dist.Normal(loc=jnp.array([5, 60]), scale=jnp.array([5, 30]))
+    gamma = numpyro.sample("gamma", dist.MixtureSameFamily(mixing_distribution=mixing_dist,
+                                                           component_distribution=component_dist))
+
+    # Expected value of outcome
+    mu_switch = calc_sn_exp_both(t_val, Amplitude, Beta, t0, gamma, trise, tfall, scalar)
+
+    # Sample!
+    # with numpyro.plate("data", len(t_val)):
+    numpyro.sample("y",
+                   dist.Normal(mu_switch, Y_unc_val),
+                   obs=Y_observed_val)
+
+
+def plot_posterior_draws_numpyro(sampler, sn, lc_path=''):
+    """
+    Plot posterior draws of model from Villar+19 to ZTF light curve
+
+    Parameters
+    ----------
+    sampler: infer.MCMC object
+        sampler run using `lc_model`
+
+    sn : string
+        ZTF name of the SN to be fit by the model
+
+    lc_path : string (optional, default = '')
+        File path to folder containing processed fps lc files from Miller+24
+    """
+    color_dict = {'ZTF_g': "MediumAquaMarine",
+                  'ZTF_r': "Crimson",
+                  'ZTF_i': "GoldenRod"}
+
+    lc_df = load_lc_df(sn, lc_path)
+    fig, ax = plt.subplots(figsize=(10, 4))
+    # TODO: return to multi-filter
+    pb = lc_df.passband.unique()[0]  # r band
+    # for pb in lc_df.passband.unique():
+    filt = pb[-1]
+    lc_df_thisfilt = lc_df[(lc_df["passband"] == f'ZTF_{filt}')]
+
+    jd0 = 2458119.5  # 2018 Jan 01
+
+    try:
+        chains = az.from_numpyro(sampler)  # az.from_netcdf(f"{out_path}/{sn}_{filt}.nc")
+    except:
+        print(f'Unable to find chains for {sn} in {pb}, skipping this filter.')
+    ax.errorbar(lc_df_thisfilt.jd.values - jd0,
+                lc_df_thisfilt.fnu_microJy.values,
+                lc_df_thisfilt.fnu_microJy_unc.values,
+                fmt='o', color=color_dict[pb])
+
+    # posterior samples
+    n_samples = len(chains.posterior.t0.values.flatten())
+    rand_idx = np.random.choice(range(n_samples),
+                                90, replace=False)
+    pi_t0 = chains.posterior.t0.values.flatten()[rand_idx]
+    pi_amp = chains.posterior.Amplitude.values.flatten()[rand_idx]
+    pi_beta = chains.posterior.Beta.values.flatten()[rand_idx]
+    pi_gamma = chains.posterior.gamma.values.flatten()[rand_idx]
+    pi_trise = chains.posterior.trise.values.flatten()[rand_idx]
+    pi_tfall = chains.posterior.tfall.values.flatten()[rand_idx]
+    pi_scalar = chains.posterior.scalar.values.flatten()[rand_idx]
+
+    t_grid_rise = jnp.linspace(pi_t0 - 150,
+                               pi_t0 + pi_gamma,
+                               num=10000)
+    ax.plot(t_grid_rise,
+            calc_sn_exp_rise(t_grid_rise,
+                             pi_amp,
+                             pi_beta,
+                             pi_t0,
+                             pi_trise,
+                             pi_scalar),
+            color=color_dict[pb], ls='--', lw=0.6, alpha=0.3)
+    t_grid_decline = jnp.linspace(pi_t0 + pi_gamma,
+                                  jnp.max(lc_df_thisfilt.jd.values) - jd0,
+                                  num=10000)
+    ax.plot(t_grid_decline,
+            calc_sn_exp_decline(t_grid_decline,
+                                pi_amp,
+                                pi_beta,
+                                pi_t0,
+                                pi_gamma,
+                                pi_trise,
+                                pi_tfall,
+                                pi_scalar),
+            color=color_dict[pb], ls='--', lw=0.6, alpha=0.3)
+
+    ax.set_xlabel('Time (JD - 2018 Jan 01)', fontsize=14)
+    ax.set_xlim(20, 600)
+    ax.set_ylim(-3 * median_abs_deviation(lc_df_thisfilt.fnu_microJy.values),
+                1.2 * jnp.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))
+    ax.set_ylabel(r'Flux ($\mu$Jy)', fontsize=14)
+    ax.tick_params(axis='both', which='major', labelsize=12)
+    fig.subplots_adjust(left=0.8, bottom=0.13, right=0.99, top=0.99)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -126,7 +126,7 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     """
 
     # Define priors based on Villar+19
-    trise = numpyro.sample("trise", dist.Uniform(low=0.01, high=50))  # dist.continuous.Uniform?
+    trise = numpyro.sample("trise", dist.Uniform(low=1e-4, high=60)) #0.01, high=50))  # dist.continuous.Uniform?
     tfall = numpyro.sample("tfall", dist.Uniform(low=1, high=300))
 
     Amp_Guess = jnp.max(Y_observed_val)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -165,7 +165,7 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
                    dist.Normal(mu_switch, Y_unc_val),
                    obs=Y_observed_val)
 
-def fit_gr(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=2, model=lc_model):
+def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=4, model=lc_model):
     """
     Fit parametric model from Villar+19 to ZTF light curve
 
@@ -393,7 +393,12 @@ def main():
                    help='path to folder containing processed fps lc file from Miller+24')
     parser.add_argument('out_path', type=str, nargs='?', default=None,
                    help='path for output MCMC chains')
-
+    parser.add_argument('num_warmup', type=int, nargs='?', default=None,
+                        help='number of warmup steps for MCMC')
+    parser.add_argument('num_samples', type=int, nargs='?', default=None,
+                        help='number of samples for MCMC')
+    parser.add_argument('num_chains', type=int, nargs='?', default=None,
+                        help='number of chains for MCMC')
 
     try:
         args = parser.parse_args()
@@ -403,7 +408,7 @@ def main():
         run = False
 
     if run:
-        fit_gr(**vars(args))
+        fit_gr_numpyro(**vars(args))
 
 if __name__ == "__main__":
     main()

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -375,7 +375,7 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
                     1.2 * jnp.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))
         ax.set_ylabel(r'Flux ($\mu$Jy)', fontsize=14)
         ax.tick_params(axis='both', which='major', labelsize=12)
-        fig.subplots_adjust(left=0.8, bottom=0.13, right=0.99, top=0.99)
+        #fig.subplots_adjust(left=0.8, bottom=0.13, right=0.99, top=0.99)
         if save_fig:
             fig.savefig(f"{lc_path}/{sn}_posterior_numpyro.png",
                         dpi=600, transparent=True)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -368,8 +368,8 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
 
         ax.set_xlabel('Time (JD - 2018 Jan 01)', fontsize=14)
         # xlim may be unstable, since we're picking a random posterior instead of the max. prob. posterior
-        x_max = np.min([pi_t0[0] + pi_gamma[0] + 10 * pi_tfall[0],
-                        np.max(lc_df_thisfilt.jd.values) - jd0 + 10])
+        x_max = jnp.min([pi_t0[0] + pi_gamma[0] + 10 * pi_tfall[0],
+                        jnp.max(lc_df_thisfilt.jd.values) - jd0 + 10])
         ax.set_xlim(pi_t0[0] - 75, x_max)
         ax.set_ylim(-3 * median_abs_deviation(lc_df_thisfilt.fnu_microJy.values),
                     1.2 * jnp.percentile(lc_df_thisfilt.fnu_microJy.values, 99.5))

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -138,9 +138,11 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     uniformbeta_low = -jnp.max(Y_observed_val) / 150
     Beta = numpyro.sample("Beta", dist.Normal(0, uniformbeta_low * (-0.3)))
 
-    t0 = numpyro.sample("t0", dist.Uniform(
-        low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
-        high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
+    #t0 = numpyro.sample("t0", dist.Uniform(
+    #    low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
+    #    high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
+    t0_uniform_prior_center = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
+    t0 = numpyro.sample("t0", dist.Gaussian(mu=t0_uniform_prior_center - 10, sigma=10))
 
     sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
     scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -142,7 +142,7 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     #    low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
     #    high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
     t0_uniform_prior_center = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
-    t0 = numpyro.sample("t0", dist.Normal(mu=t0_uniform_prior_center - 10, sigma=10))
+    t0 = numpyro.sample("t0", dist.Normal(t0_uniform_prior_center - 10, 10))
 
     sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
     scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -11,11 +11,13 @@ from scipy.stats import median_abs_deviation, truncnorm, rv_continuous, norm
 from numpyro.infer.initialization import init_to_mean, init_to_uniform, init_to_value
 
 import argparse
+import glob
+import os
 
 
-def calc_sn_exp_both(t, A, B, t0, gamma, trise, tfall, offset):
+def y_model_villar19(t, A, B, t0, gamma, trise, tfall, offset):
     """
-    Calculate the rising and declining (hence _both) portions of the SN model from Villar+19
+    Calculate the SN model from Villar+19. Incompatible with ztf priors from Superphot+
 
     Parameters
     ----------
@@ -61,8 +63,47 @@ def calc_sn_exp_both(t, A, B, t0, gamma, trise, tfall, offset):
                             (1 + jnp.exp(-(t - t0) / trise))))
     return f
 
-def y_model_superphot_plus(t, A, B, t0, gamma, trise, tfall, offset):
-    """eq. (1) from superphot_plus paper"""
+def y_model_superphot(t, A, B, t0, gamma, trise, tfall, offset):
+    """
+    Calculate the SN model from de Soto+24
+
+    Parameters
+    ----------
+    t : array-like
+        Times at which the model is evaluated
+
+    A - float
+        Constant of proportionality
+
+    B - float
+        constant of proportionality
+
+    t0 - float
+        reference time for exponential rise
+
+    gamma - float
+        time of plateau onset minus t0
+
+    trise - float
+        exponential decay factor
+
+    tfall - float
+        exponential decay factor controlling the decline
+
+    offset - float
+        scalar offset relative to 0 flux
+
+    Returns
+    -------
+    f : array-like
+        Eqn (1) from deSoto+24 for flux of SN evaluated at
+        times t
+
+    References
+    ----------
+    (1) K. M. de Soto, A. Villar, E. Berger et al. (2024)
+    Astrophysical Journal, 974, 169; doi: 10.3847/1538-4357/ad6a4f
+    """
     f = jnp.where(t - t0 < gamma,
                   
                  ((A * (1 - (B * (t - t0)))) / (1 + jnp.exp(-(t - t0) / trise))) + offset,
@@ -72,20 +113,6 @@ def y_model_superphot_plus(t, A, B, t0, gamma, trise, tfall, offset):
                             jnp.exp((gamma - (t - t0)) / tfall)
                       /
                             (1 + jnp.exp(-(t - t0) / trise))
-                           ))
-    return f
-
-def y_model_superphot_plus_logs(t, logA, B, t0, log_gamma, log_trise, log_tfall, offset):
-    """eq. (1) from superphot_plus paper"""
-    f = jnp.where(t - t0 < (10**log_gamma),
-                  
-                 (((10**logA) * (1 - (B * (t - t0)))) / (1 + jnp.exp(-(t - t0) / (10**log_trise)))) + offset,
-                 
-                  offset + (
-                      ((10**logA) * (1 - (B * (10**log_gamma)))) *
-                            jnp.exp(((10**log_gamma) - (t - t0)) / (10**log_tfall))
-                      /
-                            (1 + jnp.exp(-(t - t0) / (10**log_trise)))
                            ))
     return f
 
@@ -112,12 +139,12 @@ def load_lc_df(sn, lc_path, min_num_obs=10):
         passbands may be excluded if there were fewer than min_num_obs valid points
     """
 
+    # light curve data frame for all observations
     lc_df = pd.read_csv(f"{lc_path}/{sn}_fnu.csv")
-
+    
+    # make quality cuts
     keep_ind = []
-
-    for pb in lc_df.passband.unique():
-
+    for pb in lc_df.passband.unique(): # loop over passbands
         pb_lc = np.where((lc_df["passband"] == pb) &
                          (lc_df["flags"] == 0) &
                          # # CHECK IF THIS IS WHAT SHOULD BE DONE!!!
@@ -131,140 +158,186 @@ def load_lc_df(sn, lc_path, min_num_obs=10):
             keep_ind.append(pb_lc[0])
     if len(keep_ind) == 0:
         print(f"{sn} has 0 data points passing quality cuts; skipping this source")
-
     lc_df_clean = lc_df.iloc[np.concatenate(keep_ind)]
+    
     return lc_df_clean
 
-class TruncatedLogNormal(dist.Distribution):
-    def __init__(self, loc, scale, low, high, **kwargs):
-        # Log-normal parameters
-        self.loc = loc
-        self.scale = scale
-        self.low = low
-        self.high = high
-        super().__init__(**kwargs)
-
-    def sample(self, key, sample_shape=()):
-        # Sample from the log-normal distribution
-        log_normal_sample = dist.LogNormal(self.loc, self.scale).sample(key, sample_shape)
-        
-        # Apply truncation: enforce that the sample lies within [low, high]
-        return jnp.clip(log_normal_sample, self.low, self.high)
-
-    def log_prob(self, value):
-        # The log probability density function for truncated log-normal
-        # Apply truncation bounds in the log-prob calculation.
-        if jnp.any((value < self.low) | (value > self.high)):
-            return -jnp.inf  # Outside the bounds
-        
-        # Compute the log-probability of the log-normal distribution
-        log_prob = dist.LogNormal(self.loc, self.scale).log_prob(value)
-        return log_prob
-
 def villar_fit_constraint(x):
-    beta, gamma, tau_rise, tau_fall = x
-    return (
-        jnp.maximum(gamma - (1.0 - beta * tau_fall) / beta, 0.) +
-        jnp.maximum(jnp.exp(-gamma / tau_rise) * (1.0/beta - tau_rise - gamma) - tau_rise, 0.)
-    )
-
-def lc_model_superphot(t_val, Y_unc_val, Y_observed_val=None):
     """
-    (Non-hierarchical) model for ZTF light curves, with priors based on superphot_plus/.../numpyro_sampler.py
+    Apply constraints described in Appendix B of de Soto+24
+    1. ensure piecewise transition happens after plateau
+    2. at t - t0 = gamma, enforce negative (or 0) derivative of first piecewise portion 
+    3. at t - t0 = gamma, ensure derivative of second piecewise portion is more negative than that of first portion
+    4. (via 1-3) model flux is always positive
 
     Parameters
     ----------
-    t_val : array-like
+    x : list
+        list containing beta, gamma, trise, tfall
+
+    Returns
+    -------
+     : tuple
+        expressions (B2) and (B3) from de Soto+24
+
+    References
+    ----------
+    (1) K. M. de Soto, A. Villar, E. Berger et al. (2024)
+    Astrophysical Journal, 974, 169; doi: 10.3847/1538-4357/ad6a4f
+    (2) https://github.com/VTDA-Group/superphot-plus
+    """
+
+    #amplitude, beta, gamma, t0, trise, tfall = x
+    
+    # return ( 
+    #     jnp.maximum(gamma * beta - 1., 0.) + ##<-
+    #     jnp.maximum(jnp.exp(-gamma/trise)*(tfall/trise-1) - 1., 0.) + ##<-
+    #     jnp.maximum(beta*tfall - 1. + beta*gamma, 0.) ##<- same as eq B3 (ensure deriv. of second piecewise portion is more negative than that of first at t-t0=gamma)
+    #     #jnp.maximum(jnp.exp(-gamma / trise) * (1.0 / beta - trise - gamma) - trise, 0.) ##<- same as eq B2, and it's not getting used!! (enforce transition happens after plateau)
+    # ) <- TRANSLATED newly defined on superphot+ github 2025
+
+
+    # return (
+    #     jnp.maximum(x[2] * x[1] - 1., 0.) +
+    #     jnp.maximum(jnp.exp(-x[2]/x[4])*(x[5]/x[4]-1) - 1., 0.) +
+    #     jnp.maximum(x[1]*x[5] - 1. + x[1]*x[2], 0.)
+    #     #jnp.maximum(jnp.exp(-x[2] / x[4]) * (1.0 / x[1] - x[4] - x[2]) - x[4], 0.)
+    # ) <- newly defined on superphot+ github 2025
+
+    # -------------------------------
+    beta, gamma, trise, tau_fall = x
+
+    return (
+        jnp.maximum(gamma - (1.0 - beta * tau_fall) / beta, 0.) +  #<- same as eq B3
+        jnp.maximum(jnp.exp(-gamma / trise) * (1.0/beta - trise - gamma) - trise, 0.)
+    ) # <- as once defined on superphot+ 2024
+
+def lc_model_superphot(t_obs, Y_unc, Y_obs=None, prior_vars='old'):
+    """
+    Model for ZTF light curves, to be handed to `fit_gr_numpyro` -> `numpyro.infer.NUTS`. 
+    Uses priors based on superphot_plus/samplers/numpyro_sampler.py
+
+    Parameters
+    ----------
+    t_obs : array-like
         Time values at which the model is evaluated
 
-    Y_unc_val : array-like
-        Flux uncertainties at the observed times t_val
+    Y_unc : array-like
+        Flux uncertainties at the observed times t_obs
 
-    Y_observed_val : array-like (optional, default = None)
-        Flux observations at times t_val
+    Y_obs : array-like (optional, default = None)
+        Flux observations at times t_obs
+
+    References
+    ----------
+    (1) https://github.com/VTDA-Group/superphot-plus
     """
-    # Superphot+ priors
-    ## Define priors based on superphot_plus/surveys/ztf.yaml (reference, works for r-band)
-    Amplitude = 10 ** numpyro.sample("logA", dist.TruncatedNormal(loc=0.0957,
-                                                                    scale=0.0575,
-                                                                    low=-0.3, high=0.5, validate_args=False))
-    #logAmplitude = numpyro.sample("logA", dist.TruncatedNormal(loc=0.0957,
-    #                                                                scale=0.0575,
-    #                                                                low=-0.3, high=0.5))
-    ### max_flux = jnp.max(Y_observed_val) # TODO REMOVE MAXFLUC FROM DATA
 
-    Beta = numpyro.sample("beta", dist.TruncatedNormal(loc=0.00833,
-                                                        scale=0.00385,
-                                                        low=0, high=0.03, validate_args=False))
+    # define time of maximum, t0 prior depends on it
+    tFmax = jnp.array(t_obs)[jnp.argmax(Y_obs)]
 
-    gamma = 10 ** numpyro.sample("log_gamma", dist.TruncatedNormal(loc=1.4258, scale=0.3079, low=0, high=3.5, validate_args=False))
-    #loggamma = numpyro.sample("log_gamma", dist.TruncatedNormal(loc=1.4258, scale=0.3079, low=0, high=3.5))
+    # define priors variables from superphot_plus/surveys/ztf.yaml (reference, works for r-band)
+    old_prior_vars = {'log_amplitude': (0.0957, 0.0575,-0.3, 0.5), 
+            'beta': (0.00833, 0.00385, 0, 0.03),
+            't0': (tFmax - 17.878, 9.916, tFmax - 100, tFmax + 30), 
+            'log_gamma': (1.4258, 0.3079, 0, 3.5),
+            'log_trise': (0.6664, 0.4250, -2.0, 4.0),
+            'log_tfall': (1.5261, 0.3037, 0, 4), 
+            'log_extra_sigma': (-1.6629, 0.3378, -3, -0.8)}
+    # define priors variables from RECENTLY CHANGED, WIDER superphot_plus/surveys/ztf.yaml (reference, works for r-band)
+    new_prior_vars = {'log_amplitude': (0.0957, 0.15,-0.3, 0.5), 
+            'beta': (0.00833, 0.012, -0.01, 0.03), 
+            't0': (tFmax - 17.878, 30, tFmax - 100, tFmax + 30), 
+            'log_gamma': (1.4258, 0.9, 0, 3.5),
+            'log_trise': (0.6664, 1.2, -2.0, 4.0),
+            'log_tfall': (1.5261, 0.9, 0, 4), 
+            'log_extra_sigma': (-1.6629, 0.9, -3, -0.8)}
+    # choose which set to use
+    if prior_vars == 'old':
+        prior_vars = old_prior_vars
+        print('using old superphot+ priors (narrow)')
+    elif prior_vars == 'new':
+        prior_vars = new_prior_vars
+        print('using new superphot+ priors (wide)')
+    else:
+        print('undefined prior variables, quitting')
+        return
 
-    tFmax = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
-    t0 = numpyro.sample("t0", dist.TruncatedNormal(loc=tFmax - 17.878,
-                                                    scale=9.916,
-                                                    low=tFmax - 100, high=tFmax + 30, validate_args=False))
+    # define and un-log10- the priors where applicable
+    amplitude = 10 ** numpyro.sample("log_amplitude", dist.TruncatedNormal(loc=prior_vars["log_amplitude"][0],
+                                                                    scale=prior_vars["log_amplitude"][1],
+                                                                    low=prior_vars["log_amplitude"][2], 
+                                                                    high=prior_vars["log_amplitude"][3], validate_args=False))
 
-    trise = 10 ** numpyro.sample("log_trise", dist.TruncatedNormal(loc=0.6664, 
-                                                                    scale=0.4250, 
-                                                                    low=-2, high=4, validate_args=False))
-    #logtrise = numpyro.sample("log_trise", dist.TruncatedNormal(loc=0.6664, 
-    #                                                                scale=0.4250, 
-    #                                                                low=-2, high=4))
+    beta = numpyro.sample("beta", dist.TruncatedNormal(loc=prior_vars["beta"][0],
+                                                        scale=prior_vars["beta"][1],
+                                                        low=prior_vars["beta"][2],
+                                                        high=prior_vars["beta"][3], validate_args=False))
 
-    tfall = 10 ** numpyro.sample("log_tfall", dist.TruncatedNormal(loc=1.5261,
-                                                                    scale=0.3037,
-                                                                    low=0, high=4, validate_args=False))
-    #logtfall = numpyro.sample("log_tfall", dist.TruncatedNormal(loc=1.5261,
-    #                                                                scale=0.3037,
-    #                                                                low=0, high=4))
+    gamma = 10 ** numpyro.sample("log_gamma", dist.TruncatedNormal(loc=prior_vars["log_gamma"][0], 
+                                                                   scale=prior_vars["log_gamma"][1],
+                                                                   low=prior_vars["log_gamma"][2], 
+                                                                   high=prior_vars["log_gamma"][3], validate_args=False))
     
-    # NO EXTRA SIGMA????
-    extra_sigma = 10 ** numpyro.sample("log_extra_sigma", dist.TruncatedNormal(loc=-1.6629,
-                                                                                scale=0.3378,
-                                                                                low=-3, high=-0.8, validate_args=False))
-    
-    # TEST ADDING SCALAR (although not in superphot+ models) 
-    #sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
-    #scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,
-    #                                                       low=-2 * sigma_est,
-    #                                                       high=2 * sigma_est))
+    t0 = numpyro.sample("t0", dist.TruncatedNormal(loc=prior_vars["t0"][0],
+                                                    scale=prior_vars["t0"][1],
+                                                    low=prior_vars["t0"][2], 
+                                                    high=prior_vars["t0"][3], validate_args=False))
 
-    # TODO: NEW LC_MODEL_LOG FITTING W CONSTRAINT
-    constraint = villar_fit_constraint([Beta, gamma, trise, tfall])
+    trise = 10 ** numpyro.sample("log_trise", dist.TruncatedNormal(loc=prior_vars["log_trise"][0], 
+                                                                    scale=prior_vars["log_trise"][1],
+                                                                    low=prior_vars["log_trise"][2], 
+                                                                    high=prior_vars["log_trise"][3],
+                                                                      validate_args=False))
+
+    tfall = 10 ** numpyro.sample("log_tfall", dist.TruncatedNormal(loc=prior_vars["log_tfall"][0],
+                                                                    scale=prior_vars["log_tfall"][1],
+                                                                    low=prior_vars["log_tfall"][2], 
+                                                                    high=prior_vars["log_tfall"][3], validate_args=False))
+
+    extra_sigma = 10 ** numpyro.sample("log_extra_sigma", dist.TruncatedNormal(loc=prior_vars["log_extra_sigma"][0],
+                                                                                scale=prior_vars["log_extra_sigma"][1],
+                                                                                low=prior_vars["log_extra_sigma"][2], 
+                                                                                high=prior_vars["log_extra_sigma"][3], validate_args=False))
+    
+    # # scalar term was in Villar+19, although not in superphot+ models
+    # sigma_est = jnp.sqrt(jnp.mean(Y_unc ** 2))
+    # scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,
+    #                                                       low=-2 * sigma_est, high=2 * sigma_est))
+
+    # incorporate constraint from de Soto+24 Appendix B, this adds an arbitrary log prob. factor
+    constraint = villar_fit_constraint([beta, gamma, trise, tfall])
     numpyro.factor(
         "vf_constraint",
-        -1000. * constraint
+        -1000. * jnp.max(constraint)
     )
 
-    # Uncertainties (add extra_sigma in quad.)
-    sigma_tot = jnp.sqrt(Y_unc_val**2 + extra_sigma**2)
+    # define uncertainties (add extra_sigma to observed uncertainties in quad.)
+    sigma_tot = jnp.sqrt(Y_unc**2 + extra_sigma**2)
 
-    # Expected value of outcome - note max_flux now in amplitude
-    mu_switch = y_model_superphot_plus(t_val, Amplitude, Beta, t0, gamma, trise, tfall, 
+    # expected value of outcome
+    mu_switch = y_model_superphot(t_obs, amplitude, beta, t0, gamma, trise, tfall, 
                                  0)#,scalar)
-    #mu_switch = y_model_superphot_plus_logs(t_val, logAmplitude, Beta, t0, loggamma, logtrise, logtfall, 
-    #                             0)#,scalar)
 
     # Sample!
     numpyro.sample("y",
                    dist.Normal(mu_switch, sigma_tot),
-                   obs=Y_observed_val)
+                   obs=Y_obs)
 
-def lc_model(t_val, Y_unc_val, Y_observed_val=None):
+def lc_model_villar19_miller(t_obs, Y_unc, Y_obs=None):
     """
-    (Non-hierarchical) model for ZTF light curves, with priors loosely based on Villar+19
+    model for ZTF light curves, with priors loosely based on Villar+19, and Adam's pymc scripts
 
     Parameters
     ----------
-    t_val : array-like
+    t_obs : array-like
         Time values at which the model is evaluated
 
-    Y_unc_val : array-like
-        Flux uncertainties at the observed times t_val
+    Y_unc : array-like
+        Flux uncertainties at the observed times t_obs
 
-    Y_observed_val : array-like (optional, default = None)
-        Flux observations at times t_val
+    Y_obs : array-like (optional, default = None)
+        Flux observations at times t_obs
     """
 
     # Define priors based on Villar+19
@@ -272,22 +345,22 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     #trise = numpyro.sample("trise", dist.TruncatedNormal(loc=6, scale=2, low=0))
     tfall = numpyro.sample("tfall", dist.Uniform(low=1, high=300))
 
-    Amp_Guess = jnp.max(Y_observed_val)
-    Amplitude = numpyro.sample("Amplitude", dist.TruncatedNormal(
+    Amp_Guess = jnp.max(Y_obs)
+    amplitude = numpyro.sample("amplitude", dist.TruncatedNormal(
         loc=Amp_Guess,
         scale=Amp_Guess / 10, low=0))
 
-    Beta = numpyro.sample("Beta", dist.Uniform(low=-jnp.max(Y_observed_val) / 150, high=0))
-    #uniformbeta_low = -jnp.max(Y_observed_val) / 150
-    #Beta = numpyro.sample("Beta", dist.Normal(0, uniformbeta_low * (-0.3)))
+    beta = numpyro.sample("beta", dist.Uniform(low=-jnp.max(Y_obs) / 150, high=0))
+    #uniformbeta_low = -jnp.max(Y_obs) / 150
+    #beta = numpyro.sample("beta", dist.Normal(0, uniformbeta_low * (-0.3)))
 
     t0 = numpyro.sample("t0", dist.Uniform(
-        low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
-        high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
-    #t0_uniform_prior_center = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
+        low=jnp.array(t_obs)[jnp.argmax(Y_obs)] - 25,
+        high=jnp.array(t_obs)[jnp.argmax(Y_obs)] + 25))
+    #t0_uniform_prior_center = jnp.array(t_obs)[jnp.argmax(Y_obs)]
     #t0 = numpyro.sample("t0", dist.Normal(t0_uniform_prior_center - 10, 10))
 
-    sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
+    sigma_est = jnp.sqrt(jnp.mean(Y_unc ** 2))
     scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,
                                                            low=-2 * sigma_est,
                                                            high=2 * sigma_est))
@@ -308,16 +381,16 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
 
 
     # Expected value of outcome
-    mu_switch = calc_sn_exp_both(t_val, Amplitude, Beta, t0, gamma, trise, tfall, scalar)
+    mu_switch = y_model_villar19(t_obs, amplitude, beta, t0, gamma, trise, tfall, scalar)
 
     # Sample!
     numpyro.sample("y",
-                   dist.Normal(mu_switch, Y_unc_val),
-                   obs=Y_observed_val)
+                   dist.Normal(mu_switch, Y_unc),
+                   obs=Y_obs)
 
-def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=4, init_strat='uniform', model=lc_model_superphot, init_values = None, randomkey=0):
+def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=4, init_strat='uniform', model=lc_model_superphot, randomkey=0, jd0 = 2458119.5):
     """
-    Fit parametric model from Villar+19 [OR deSoto+24] to ZTF light curve
+    Fit parametric model from [Villar+19 OR de Soto+24/Superphot+] to all light curves (in available filters) from a single object `sn`.
 
     Parameters
     ----------
@@ -330,162 +403,88 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
     out_path : string (optional, default = '')
         File path to write output files (MCMC chains and summary statistics)
 
-    num_warmup : int (optional, default = 1500)
+    num_warmup : int (optional, default = 15000)
         Number of warmup steps to run MCMC chains for
 
     num_samples : int (optional, default = 1000)
         Number of samples to run MCMC chains for
 
-    num_chains : int (optional, default = 2)
+    num_chains : int (optional, default = 4)
         Number of chains to run MCMC, make sure num_chains =< jax.local_device_count()
         ( you can change device count using: numpyro.set_host_device_count(#) )
 
     init_strat : str (optional, default = 'uniform')
-        Number of chains to run MCMC, make sure num_chains =< jax.local_device_count()
-        ( you can change device count using: numpyro.set_host_device_count(#) )
+        Initialization strategy for numpyro, can be 'uniform', 'mean', or 'value'.
+        See https://num.pyro.ai/en/stable/utilities.html#init-strategy for details.
 
-    model : function (optional, default = lc_model)
-        numpyro modeling function, either hierarchical (WIP) or non-hierarchical (lc_model)
+    model : function (optional, default = lc_model_superphot)
+        numpyro modeling function from Villar19+ (lc_model_villar19_miller) OR non-hierarchical superphot+ (lc_model_superphot)
     """
 
-    # load dataframe with some quality cuts
+    # load light curve dataframe with some quality cuts
     lc_df = load_lc_df(sn=sn, lc_path=lc_path)
 
-    for pb in lc_df.passband.unique():
+    for pb in lc_df.passband.unique(): # loop over available passbands
+        # preprocessing data
         filt = pb[-1]
-
-        # Fit the model with the current filter
+        ## fit the model with the current filter
         lc_df_thisfilt = lc_df[(lc_df["passband"] == f'ZTF_{filt}')]
+        ## shift obs. times relative to 2018 Jan 01
+        t_obs_shifted = (lc_df_thisfilt['jd'].values) - jd0
+        ## scale flux and flux uncertainty down by max. observed flux
+        Y_obs_orig = ((lc_df_thisfilt['fnu_microJy']).values)
+        Y_obs_max = jnp.max(Y_obs_orig)
+        print(f'scaling data by dividing by Y_observed_max: {Y_obs_max}. keep in mind when visualizing posterior draws!!!')
+        np.save(f'{out_path}/{sn}_{filt}_maxflux_{Y_obs_max}.npy', Y_obs_max) # save Y_obs_max, it's important for later!!!
 
-        jd0 = 2458119.5  # 2018 Jan 01
-        time_axis = (lc_df_thisfilt['jd'].values) - jd0
+        Y_obs_scaled = Y_obs_orig / Y_obs_max
+        Y_unc_scaled = ((lc_df_thisfilt['fnu_microJy_unc']).values) / Y_obs_max
 
-        Y_observed_orig = ((lc_df_thisfilt['fnu_microJy']).values)
-        Y_observed_max = jnp.max(Y_observed_orig)
-        print(f'scaling data by dividing by Y_obserbed_max: {Y_observed_max}. keep in mind when visualizing posterior draws!!!')
-        Y_observed = Y_observed_orig / Y_observed_max
+        # initalization strategy
+        ## map input "init_strat" string to define strategy
+        init_strat_dict = {'uniform' : init_to_uniform,
+                       'mean': init_to_mean,
+                       'value': "need init. values"}
+        this_init_strat = init_strat_dict[init_strat]
+        ## specify initalization values (hardcoded for now, should only be used for testing)
+        if (this_init_strat == "need init. values") & (model == lc_model_superphot):
+            print('warning: init_to_value method is hardcoded')
+            # amp	beta	t0	gamma	trise	tfall
+            #truths = [1.196678, 0.013459, 1382.580604, 60.483029, 5.535795, 22.128788]
+            truths = [0.116, 0.012, 1.548, 1409.233, 0.415, 1.519, -1.66] # LOGGED APPROPRIATELY, in order of table in diagnos. plot
+            ## note t0 and log_gamma listed in swapped order above
+            this_init_strat = init_to_value(values = {"log_amplitude": truths[0], "beta": truths[1], 
+                                                    "t0": truths[3], "log_gamma": truths[2],
+                                                    "log_trise": truths[4], 
+                                                    "log_tfall": truths[5], "scalar": truths[6]})
+        elif init_strat not in ['uniform', 'mean', 'value']:
+            print('could not define initialization strategy based on inputs!')
+            return
 
-        Y_unc_orig = ((lc_df_thisfilt['fnu_microJy_unc']).values)
-        Y_unc = ((lc_df_thisfilt['fnu_microJy_unc']).values) / Y_observed_max
-
-        if init_strat == 'uniform':
-            init_strategy = init_to_uniform
-        elif init_strat == 'mean':
-            init_strategy = init_to_mean
-        elif init_strat == 'value':# & (model == lc_model_superphot):
-            print('warning: init_to_value is hardcoded')
-            Amp_Guess = jnp.max(Y_observed)
-            # gaussian t0 center
-            #t0_uniform_prior_center = jnp.array(time_axis)[jnp.argmax(Y_observed)] - 10
-
-            ## VALUES FOR ZTF18abxoqkd; superphot+ translated but linear
-            #init_strategy = init_to_value(values = {"logA": 1.0573, "beta": 0.0022, "t0": 1408.2236, "log_gamma": 10.5832,
-            #                                        "log_trise": 2.3345, "log_tfall": 17.1516, "scalar": 0})
-            # logged vers.
-            init_strategy = init_to_value(values = {"logA": np.log10(1.0573), "beta": 0.0022, "t0": 1408.2236, "log_gamma": np.log10(10.5832),
-                                                    "log_trise": np.log10(2.3345), "log_tfall": np.log10(17.1516), "scalar": 0})
-            #if init_values is not None:
-            #    init_strategy = init_to_value(values = init_values)
-            #else:
-            #    print('could not use init_to_value, missing values')
-        else:
-            print('could not define initialization strategy based on input!')
-
+        # numpyro setup
         sampler = infer.MCMC(
-            infer.NUTS(model, init_strategy = init_strategy),
-            num_warmup=num_warmup,
-            num_samples=num_samples,
-            num_chains=num_chains,
-            progress_bar=True,
-            chain_method="parallel")
-        #sampler.warmup(jax.random.PRNGKey(randomkey), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
-        #warmup_samples = sampler.get_samples()
-        #np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
+            infer.NUTS(model, init_strategy = this_init_strat),
+            num_warmup=num_warmup, num_samples=num_samples, num_chains=num_chains,
+            progress_bar=True, chain_method="parallel")
+        ## collecting warmup sample chains (for testing)
+        sampler.warmup(jax.random.PRNGKey(randomkey), t_obs_shifted, Y_unc_scaled, Y_obs=Y_obs_scaled, collect_warmup=True)
+        warmup_samples = sampler.get_samples()
+        np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
 
-        # Draw samples from the posterior
-        sampler.run(jax.random.PRNGKey(randomkey), time_axis, Y_unc, Y_observed_val=Y_observed)
+        ## draw samples from the posterior
+        sampler.run(jax.random.PRNGKey(randomkey), t_obs_shifted, Y_unc_scaled, Y_obs=Y_obs_scaled)
+        ## collecting sampling chains (for testing)
         #samples = sampler.get_samples()
         #np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
 
-        # Save results
+        ## save results
         data = az.from_numpyro(sampler)
         data.to_netcdf(f"{out_path}/{sn}_{filt}_numpyro.nc")
         out_summary = f"{out_path}/{sn}_{filt}_numpyro.csv"
         az.summary(data, stat_focus='median').to_csv(out_summary)
 
+# --- --- functions for visualizing results from Villar19+ fits (does not work for Superphot+ fits)
 
-def lc_model_hier_oneSN(t_val, Y_unc_val, Y_observed_val=None):
-    """
-    Work in progress!!
-    Hierarchical model for ZTF light curves, with priors loosely based on Villar+19
-
-    Parameters
-    ----------
-    t_val : array-like
-        Time values at which the model is evaluated
-
-    Y_unc_val : array-like
-        Flux uncertainties at the observed times t_val
-
-    Y_observed_val : array-like (optional, default = None)
-        Flux observations at times t_val
-    """
-
-    # Define priors based on Villar+19
-    trise_low = numpyro.sample("trise_low", dist.Uniform(low=5e-3, high=0.02))
-    trise_high = numpyro.sample("trise_high", dist.Uniform(low=45, high=55))
-    trise = numpyro.sample("trise", dist.Uniform(low=trise_low, high=trise_high)) #0.01,50 # dist.continuous.Uniform?
-
-
-    tfall_low = numpyro.sample("tfall_low", dist.Uniform(low=0.5, high=1.5))
-    tfall_high = numpyro.sample("tfall_high", dist.Uniform(low=295, high=305))
-    tfall = numpyro.sample("tfall", dist.Uniform(low=tfall_low, high=tfall_high))
-
-
-    Amp_Guess = jnp.max(Y_observed_val)
-    Amp_mu = numpyro.sample("Amp_mu", dist.Uniform(low=Amp_Guess-500, high=Amp_Guess+500))
-    #Amp_sigma = numpyro.sample("Amp_sigma", dist.Uniform(low=Amp_Guess/11, high=Amp_Guess/9))
-    Amplitude = numpyro.sample("Amplitude", dist.TruncatedNormal(
-        loc=Amp_mu,
-        scale=Amp_Guess / 10, low=0))
-        #loc=Amp_Guess,
-        #scale=Amp_Guess / 10, low=0))
-
-    Beta = numpyro.sample("Beta", dist.Uniform(low=-jnp.max(Y_observed_val) / 150, high=0))
-
-    t0 = numpyro.sample("t0", dist.Uniform(
-        low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
-        high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
-
-    sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
-    scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,
-                                                           low=-2 * sigma_est,
-                                                           high=2 * sigma_est))
-
-    ## gamma's prior is a normal mixture - not straightforward in numpyro
-    # Define the weights for the mixture components
-    weights = jnp.array([2 / 3, 1 / 3])  # Should sum to 1
-    # Define means and standard deviations for the normal components
-    means, stds = jnp.array([5, 60]), jnp.array([5, 30])
-    # Define the normal distributions
-    components = [dist.Normal(mu, sigma) for mu, sigma in zip(means, stds)]
-    # Define the mixture distribution
-    mixture = dist.Mixture(
-        dist.Categorical(probs=weights),  # Mixture weights
-        components  # List of component distributions
-    )
-    gamma = numpyro.sample("gamma", mixture)
-
-    # Expected value of outcome
-    mu_switch = calc_sn_exp_both(t_val, Amplitude, Beta, t0, gamma, trise, tfall, scalar)
-
-    # Sample!
-    # with numpyro.plate("data", len(t_val)):
-    numpyro.sample("y",
-                   dist.Normal(mu_switch, Y_unc_val),
-                   obs=Y_observed_val)
-
-# --- functions we need to calculate posterior from numpyro chains ---
 class MixtureModel(rv_continuous):
     def __init__(self, submodels, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -504,23 +503,22 @@ class MixtureModel(rv_continuous):
         rvs = np.choose(submodel_choices, submodel_samples)
         return rvs
 
-
 def posterior_from_chains(chains_filt, y_obs_filt, y_unc_filt):
     """
     for one filter, calculate posterior (at every step in every chain)
     """
     # posterior = prior * likelihood
     ## grab likelihoods from chains, define priors from scratch
-
+    
     # define log likelihood for the (4) chains
     summed = np.sum(chains_filt.log_likelihood.y.values, axis=2)
 
     # define all ~gaussian priors (ignore uniform)
 
     ## scalar (truncnorm)
-    sigma_est = np.sqrt(np.mean(y_unc_filt ** 2))
-    myclip_low = -2 * sigma_est
-    myclip_high = 2 * sigma_est
+    sigma_est = np.sqrt(np.mean(y_unc_filt**2))
+    myclip_low = -2* sigma_est
+    myclip_high = 2* sigma_est
     low, high = (myclip_low - 0) / sigma_est, (myclip_high - 0) / sigma_est
     rv = truncnorm(low, high, loc=0, scale=sigma_est)
     ln_scalar = np.log(rv.pdf(chains_filt.posterior.scalar))
@@ -528,24 +526,20 @@ def posterior_from_chains(chains_filt, y_obs_filt, y_unc_filt):
     ## Amplitude (truncnorm)
     amp_guess = np.max(y_obs_filt)
     myclip_low_amp = 0
-    myclip_high_amp = 3 * amp_guess
-    low_amp, high_amp = (myclip_low_amp - amp_guess) / (amp_guess / 10), (myclip_high_amp - amp_guess) / (
-                amp_guess / 10)
-    rv_2 = truncnorm(low_amp, high_amp, loc=amp_guess, scale=amp_guess / 10)
+    myclip_high_amp = 3*amp_guess
+    low_amp, high_amp = (myclip_low_amp - amp_guess) / (amp_guess/10), (myclip_high_amp - amp_guess) / (amp_guess/10)
+    rv_2 = truncnorm(low_amp, high_amp, loc=amp_guess, scale=amp_guess/10)
     ln_amp = np.log(rv_2.pdf(chains_filt.posterior.Amplitude))
 
     ## Gamma (normal mixture)
-    mixture_gaussian_model = MixtureModel(
-        [norm(5, 5), norm(5, 5), norm(60, 30)])  # cheat the 2/3 and 1/3 weights by mixing 3 normals
+    mixture_gaussian_model = MixtureModel([norm(5, 5), norm(5, 5), norm(60, 30)]) # cheat the 2/3 and 1/3 weights by mixing 3 normals
     ln_gamma = np.log(mixture_gaussian_model.pdf(chains_filt.posterior.gamma))
 
-    # posterior calc
+    # posterior calc 
     ln_posterior = summed + ln_scalar + ln_amp + ln_gamma
     return ln_posterior
 
-# --- ---
-
-def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
+def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True, jd0 = 2458119.5):
     """
     Plot posterior draws of model from Villar+19 to ZTF light curve
 
@@ -571,11 +565,9 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
     fig, ax = plt.subplots(figsize=(10, 4))
     xlims, ylims = [], []
     for pb in lc_df.passband.unique():
-        filt = pb[-1]
+        filt = [-1]
 
         lc_df_thisfilt = lc_df[(lc_df["passband"] == f'ZTF_{filt}')]
-
-        jd0 = 2458119.5  # 2018 Jan 01
 
         try:
             chains = az.from_netcdf(f"{out_path}/{sn}_{filt}_numpyro.nc")
@@ -593,8 +585,8 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
                                      lc_df_thisfilt['fnu_microJy_unc'])
         pi_max_index = np.argmax(post.flatten())
         pi_max_t0 = chains.posterior.t0.values.flatten()[pi_max_index]
-        pi_max_amp = chains.posterior.Amplitude.values.flatten()[pi_max_index]
-        pi_max_beta = chains.posterior.Beta.values.flatten()[pi_max_index]
+        pi_max_amp = chains.posterior.amplitude.values.flatten()[pi_max_index]
+        pi_max_beta = chains.posterior.beta.values.flatten()[pi_max_index]
         pi_max_gamma = chains.posterior.gamma.values.flatten()[pi_max_index]
         pi_max_trise = chains.posterior.trise.values.flatten()[pi_max_index]
         pi_max_tfall = chains.posterior.tfall.values.flatten()[pi_max_index]
@@ -604,7 +596,7 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
                               jnp.max(lc_df_thisfilt.jd.values) - jd0,
                               num=20000)
         ax.plot(t_grid,
-                calc_sn_exp_both(t_grid,
+                y_model_villar19(t_grid,
                                  pi_max_amp,
                                  pi_max_beta,
                                  pi_max_t0,
@@ -619,8 +611,8 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
         rand_idx = np.random.choice(range(n_samples),
                                     10, replace=False)
         pi_t0 = chains.posterior.t0.values.flatten()[rand_idx]
-        pi_amp = chains.posterior.Amplitude.values.flatten()[rand_idx]
-        pi_beta = chains.posterior.Beta.values.flatten()[rand_idx]
+        pi_amp = chains.posterior.amplitude.values.flatten()[rand_idx]
+        pi_beta = chains.posterior.beta.values.flatten()[rand_idx]
         pi_gamma = chains.posterior.gamma.values.flatten()[rand_idx]
         pi_trise = chains.posterior.trise.values.flatten()[rand_idx]
         pi_tfall = chains.posterior.tfall.values.flatten()[rand_idx]
@@ -630,7 +622,7 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
                               np.max(lc_df_thisfilt.jd.values) - jd0,
                               num=20000)
         ax.plot(t_grid,
-                calc_sn_exp_both(t_grid,
+                y_model_villar19(t_grid,
                                  pi_amp,
                                  pi_beta,
                                  pi_t0,
@@ -660,7 +652,446 @@ def plot_posterior_draws_numpyro(sn, lc_path='', out_path='', save_fig=True):
     if save_fig:
         fig.savefig(f"{lc_path}/{sn}_posterior_numpyro.png",
                     dpi=600, transparent=True)
+
+# --- DIAGNOSTIC PLOTS ---
+def lnl_from_sim(fake_lc, truth, max_flux, jd0 = 2458119.5):
+    """
+    knowing the true model param. values (from simulation), calculate lnl with sim. data and sim. truth model
+    returns: a single value!
+    """
     
+    # simulated SN data
+    data = fake_lc['fnu_microJy']
+    N = len(data)
+    #max_flux = np.max(fake_lc_smooth['fnu_microJy'])
+    unc = fake_lc['fnu_microJy_unc']
+
+    # model using the "true" params from which SN was simulated
+    model = max_flux * y_model_superphot(fake_lc['jd'].values-jd0, truth['amp'][0], 
+                                   truth['beta'][0], truth['t0'][0], 
+                                   truth['gamma'][0], truth['trise'][0], truth['tfall'][0], 0)
+
+    # log likelihood calc.
+    lnl = (-1 * (N/2) * np.log(2*np.pi)) - (np.sum(np.log(unc))) -1 * np.sum((data - model)**2 / (2 * unc**2))
+    return lnl
+
+def lnl_from_chains(fake_lc, chains, max_flux, jd0 = 2458119.5):
+    """
+    making this because we think the log_likelihood var is incorrect. calc manually!!
+    returns: list of len = nchains, each entry is a list of len = nsteps (aka one lnl value for every step in each chain)
+    """
+
+    # simulated SN data
+    data = fake_lc['fnu_microJy']
+    N = len(data)
+    unc = fake_lc['fnu_microJy_unc']
+    
+
+    # access parameter values across nchains and over nsteps
+    nchains = chains.posterior.log_amplitude.values.shape[0]
+    nsteps = chains.posterior.log_amplitude.values.shape[1]
+
+    lnl_chains = []
+
+    for i in range(nchains): # loop over chains
+        amp_step = 10 ** chains.posterior.log_amplitude.values[i]
+        beta_step = chains.posterior.beta.values[i]
+        gamma_step = 10 ** chains.posterior.log_gamma.values[i]
+        t0_step = chains.posterior.t0.values[i]
+        tfall_step = 10 ** chains.posterior.log_tfall.values[i]
+        trise_step = 10 ** chains.posterior.log_trise.values[i]
+        extra_sigma_step = 10 ** chains.posterior.log_extra_sigma.values[i]
+
+        lnl_chain = []
+        for j in range(nsteps):
+            # model at every step of the chains
+            model = max_flux * y_model_superphot(fake_lc['jd'].values-jd0, amp_step[j], 
+                                    beta_step[j], t0_step[j],
+                                    gamma_step[j], trise_step[j], tfall_step[j], 0)
+            
+            
+            sigma_tot = np.sqrt(unc**2 + extra_sigma_step[j]**2)
+
+            # log likelihood calc.
+            lnl_step = (-1 * (N/2) * np.log(2*np.pi)) - (np.sum(np.log(sigma_tot))) -1 * np.sum((data - model)**2 / (2 * sigma_tot**2))
+            lnl_chain.append(lnl_step)
+        lnl_chains.append(lnl_chain)
+    return lnl_chains
+
+def get_truncated_normal(mean=0, sd=1, low=0, upp=10):
+    '''redefines inputs, see note at: 
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html'''
+    return truncnorm(
+        (low - mean) / sd, (upp - mean) / sd, loc=mean, scale=sd)
+
+def posterior_from_chains_superphot(data, chains, max_flux, prior_vers = 'old', jd0 = 2458119.5):
+    """
+    for one filter, calculate posterior (at every step in every chain)
+    """
+
+    y_obs_filt, y_unc_filt, t_obs = data['fnu_microJy'], data['fnu_microJy_unc'], data['jd'] - jd0
+    tFmax = np.array(t_obs)[np.argmax(y_obs_filt)]
+
+    old_prior_vars = {'log_amplitude': (0.0957, 0.0575,-0.3, 0.5), 
+            'Beta': (0.00833, 0.00385, 0, 0.03),
+            't0': (tFmax - 17.878, 9.916, tFmax - 100, tFmax + 30), 
+            'log_gamma': (1.4258, 0.3079, 0, 3.5),
+            'log_trise': (0.6664, 0.4250, -2.0, 4.0),
+            'log_tfall': (1.5261, 0.3037, 0, 4), 
+            'log_extra_sigma': (-1.6629, 0.3378, -3, -0.8)}
+
+    # posterior = prior * likelihood
+    ## define priors from scratch, grab likelihoods from chains
+    
+    # define log likelihood for the (4) chains
+    ##summed = np.sum(chains_filt.log_likelihood.y.values, axis=2)
+    lnl_all_steps = lnl_from_chains(data, chains, max_flux)
+    print(np.array(lnl_all_steps).shape)
+    #lnl_summed = np.sum(np.array(lnl_all_steps), axis=1)
+    #print(lnl_summed.shape)
+
+    
+    # define all ~gaussian priors
+
+    if prior_vers == 'old':
+        p = old_prior_vars
+        ## amplitude ( log truncnorm )
+
+        log10_amp = get_truncated_normal(mean=p['log_amplitude'][0], sd=p['log_amplitude'][1], low=p['log_amplitude'][2], upp=p['log_amplitude'][3])
+        ln_amp = np.log((log10_amp.pdf(chains.posterior.log_amplitude)))
+
+        ## beta ( truncnorm )
+        beta = get_truncated_normal(mean=p['Beta'][0], sd=p['Beta'][1], low=p['Beta'][2], upp=p['Beta'][3])
+        ln_beta = np.log(beta.pdf(chains.posterior.beta))
+
+        ## gamma ( log truncnorm )
+        log10_gamma = get_truncated_normal(mean=p['log_gamma'][0], sd=p['log_gamma'][1], low=p['log_gamma'][2], upp=p['log_gamma'][3])
+        ln_gamma = np.log((log10_gamma.pdf(chains.posterior.log_gamma)))
+        
+        ## t0 ( truncnorm )
+        t0 = get_truncated_normal(mean=p['t0'][0], sd=p['t0'][1], low=p['t0'][2], upp=p['t0'][3])
+        ln_t0 = np.log(t0.pdf(chains.posterior.t0))
+
+        ## trise ( log truncnorm )
+        log10_trise = get_truncated_normal(mean=p['log_trise'][0], sd=p['log_trise'][1], low=p['log_trise'][2], upp=p['log_trise'][3])
+        ln_trise = np.log((log10_trise.pdf(chains.posterior.log_trise)))
+
+        ## tfall ( log truncnorm )
+        log10_tfall = get_truncated_normal(mean=p['log_tfall'][0], sd=p['log_tfall'][1], low=p['log_tfall'][2], upp=p['log_tfall'][3])
+        ln_tfall = np.log((log10_tfall.pdf(chains.posterior.log_tfall)))
+
+        ## extra_sigma ( log truncnorm )
+        log10_extrasigma = get_truncated_normal(mean=p['log_extra_sigma'][0], sd=p['log_extra_sigma'][1], low=p['log_extra_sigma'][2], upp=p['log_extra_sigma'][3])
+        ln_extrasigma = np.log(log10_extrasigma.pdf(chains.posterior.log_extra_sigma))
+
+        # posterior calc 
+        ln_posterior = lnl_all_steps + ln_amp + ln_beta + ln_gamma + ln_t0 + ln_trise + ln_tfall + ln_extrasigma
+        
+        return ln_posterior
+
+    else:
+        print('undefined prior variables')
+        return
+
+def posterior_from_sim_superphot(data, truths, max_flux, prior_vers = 'old', jd0 = 2458119.5):
+    """
+    for one filter, calculate posterior (at every step in every chain)
+    """
+
+    y_obs_filt, y_unc_filt, t_obs = data['fnu_microJy'], data['fnu_microJy_unc'], data['jd'] - jd0
+    tFmax = np.array(t_obs)[np.argmax(y_obs_filt)]
+
+    old_prior_vars = {'log_amplitude': (0.0957, 0.0575,-0.3, 0.5), 
+            'Beta': (0.00833, 0.00385, 0, 0.03),
+            't0': (tFmax - 17.878, 9.916, tFmax - 100, tFmax + 30), 
+            'log_gamma': (1.4258, 0.3079, 0, 3.5),
+            'log_trise': (0.6664, 0.4250, -2.0, 4.0),
+            'log_tfall': (1.5261, 0.3037, 0, 4), 
+            'log_extra_sigma': (-1.6629, 0.3378, -3, -0.8)}
+
+    # define priors variables from RECENTLY CHANGED, WIDER superphot_plus/surveys/ztf.yaml (reference, works for r-band)
+    new_prior_vars = {'log_amplitude': (0.0957, 0.15,-0.3, 0.5), 
+            'beta': (0.00833, 0.012, -0.01, 0.03), 
+            't0': (tFmax - 17.878, 30, tFmax - 100, tFmax + 30), 
+            'log_gamma': (1.4258, 0.9, 0, 3.5),
+            'log_trise': (0.6664, 1.2, -2.0, 4.0),
+            'log_tfall': (1.5261, 0.9, 0, 4), 
+            'log_extra_sigma': (-1.6629, 0.9, -3, -0.8)}
+
+    # posterior = prior * likelihood
+    ## define priors from scratch, grab likelihoods from chains
+    
+    # define log likelihood for the (4) chains
+    ##summed = np.sum(chains_filt.log_likelihood.y.values, axis=2)
+    lnl_summed = lnl_from_sim(data, truths, max_flux)
+
+    
+    # define all ~gaussian priors
+
+    if prior_vers == 'old':
+        p = old_prior_vars
+    elif prior_vers == 'new':
+        p = new_prior_vars
+    else:
+        print('undefined prior variables')
+        return
+    
+    ## amplitude ( log truncnorm )
+
+    log10_amp = get_truncated_normal(mean=p['log_amplitude'][0], sd=p['log_amplitude'][1], low=p['log_amplitude'][2], upp=p['log_amplitude'][3])
+    ln_amp = np.log(log10_amp.pdf(np.log10(truths['amp'][0])))
+
+
+    ## beta ( truncnorm )
+    beta = get_truncated_normal(mean=p['Beta'][0], sd=p['Beta'][1], low=p['Beta'][2], upp=p['Beta'][3])
+    ln_beta = np.log(beta.pdf(truths['beta'][0]))
+
+    ## gamma ( log truncnorm )
+    log10_gamma = get_truncated_normal(mean=p['log_gamma'][0], sd=p['log_gamma'][1], low=p['log_gamma'][2], upp=p['log_gamma'][3])
+    ln_gamma = np.log(log10_gamma.pdf(np.log10(truths['gamma'])))
+    
+    ## t0 ( truncnorm )
+    t0 = get_truncated_normal(mean=p['t0'][0], sd=p['t0'][1], low=p['t0'][2], upp=p['t0'][3])
+    ln_t0 = np.log(t0.pdf(truths['t0'][0]))
+
+    ## trise ( log truncnorm )
+    log10_trise = get_truncated_normal(mean=p['log_trise'][0], sd=p['log_trise'][1], low=p['log_trise'][2], upp=p['log_trise'][3])
+    ln_trise = np.log(log10_trise.pdf(np.log10(truths['trise'][0])))
+
+    ## tfall ( log truncnorm )
+    log10_tfall = get_truncated_normal(mean=p['log_tfall'][0], sd=p['log_tfall'][1], low=p['log_tfall'][2], upp=p['log_tfall'][3])
+    ln_tfall = np.log(log10_tfall.pdf(np.log10(truths['tfall'][0])))
+
+    ## extra_sigma ( log truncnorm )
+    log10_extrasigma = get_truncated_normal(mean=p['log_extra_sigma'][0], sd=p['log_extra_sigma'][1], low=p['log_extra_sigma'][2], upp=p['log_extra_sigma'][3])
+    ln_extrasigma = np.log(log10_extrasigma.pdf(p['log_extra_sigma'][0])) # TODO: check
+
+    # posterior calc 
+    ln_posterior = lnl_summed + ln_amp + ln_beta + ln_gamma + ln_t0 + ln_trise + ln_tfall + ln_extrasigma
+
+    
+    return ln_posterior
+
+    
+
+def superphot_sim_fits(fake_lc, chains, max_flux, n_idx = 30, jd0 = 2458119.5):
+
+    ## posterior samples
+    n_samples = len(chains.posterior.t0.values.flatten())
+    rand_idx = np.random.choice(range(n_samples),
+                                n_idx, replace=False)
+    pi_t0 = chains.posterior.t0.values.flatten()[rand_idx]
+    pi_amp =  max_flux * 10**chains.posterior.log_amplitude.values.flatten()[rand_idx]
+    pi_beta = chains.posterior.beta.values.flatten()[rand_idx]
+    pi_gamma = 10**chains.posterior.log_gamma.values.flatten()[rand_idx]
+    pi_trise = 10**chains.posterior.log_trise.values.flatten()[rand_idx]
+    pi_tfall = 10**chains.posterior.log_tfall.values.flatten()[rand_idx]
+
+    ## overplot posterior draws
+    t_grid = jnp.linspace(pi_t0[0] - 150,
+                            np.max(fake_lc.jd.values) - jd0,
+                            num=1000)
+    fit_arrays = []
+    for e in range(n_idx):
+        f_model = y_model_superphot(t_grid, pi_amp[e], pi_beta[e], pi_t0[e], pi_gamma[e],
+                                        pi_trise[e], pi_tfall[e], 0)
+        fit_arrays.append(f_model)
+
+    return t_grid, fit_arrays
+
+def steps_from_npy(path, nchains, nsteps, param_names = ['log_amplitude', 'beta', 'log_gamma', 't0', 'log_trise', 'log_tfall', 'log_extra_sigma']):
+    loaded = np.load(path, allow_pickle=True).item()
+    if loaded['beta'].shape[0]/nsteps != nchains:
+        print('error loading warmup: something is wrong with input nchains and/or nsteps')
+        return
+    else:
+        chainsteps = []
+        for param in param_names:
+            chainsteps.append(loaded[param].reshape(nchains,nsteps))
+    return chainsteps
+
+def params_table_truth_init(warmup_path, nchains, nsteps_warmup, truth_path=None):
+    if truth_path is not None:
+        # true values, make base df
+        truth = pd.read_csv(truth_path)
+        tab_logs = pd.DataFrame(np.array([np.log10(truth['amp']), truth['beta'], np.log10(truth['gamma']), 
+                                        truth['t0'], np.log10(truth['trise']), np.log10(truth['tfall']), np.array([0])]).T, 
+                                        columns=['log_amp', 'beta', 'log_gamma', 't0', 'log_trise', 'log_tfall', 'log_extra_sigma'])
+        index_names = ['truth']
+    else:
+        tab_logs = pd.DataFrame(columns=['log_amp', 'beta', 'log_gamma', 't0', 'log_trise', 'log_tfall', 'log_extra_sigma'])
+        index_names = []
+    pd.set_option('display.precision', 3)
+    pd.set_option('display.width', 90)
+    
+    
+    # add rows w inital values from warmup chains
+    warmup_steps = steps_from_npy(warmup_path, nchains, nsteps_warmup)
+    for c in range(nchains):
+        tab_logs.loc[-1] = [float(array[c][0]) for array in warmup_steps]
+        tab_logs.index = tab_logs.index + 1  # shifting index
+        index_names.append(f'c{c}_init') # name this row
+    tab_logs.index = index_names # assign row names
+    return tab_logs
+
+def summary_plot(sn_name, lc_folder_path, fit_folder_path, band, is_sim, init_method, nsteps_warmup, xlim_for_draws=None, save_fig=True, jd0 = 2458119.5):
+
+    #- run and fit a simulation
+    #- as output w plots for a single run;
+    #- “truth” values of simulation
+    #- exactly where we are initializing (store warmup)
+    #    - (clearly something strange, e.g. trise at 2*)
+    #- plot of every individual chain for every parameter (see whether or not params are where we expect)
+    #- plots of log likelihood
+    #    - one i calculate and numpyro calculates
+    #- plots of the posterior (log likelihood + log prior)
+    #- plot of some fits
+
+    # define all paths based on inputs
+    fitname = f'{fit_folder_path}/{sn_name}_{band}_numpyro.nc'
+    chains = az.from_netcdf(fitname) #### many things come from this
+    # access parameter values across nchains and over nsteps
+    nchains = chains.posterior.log_amplitude.values.shape[0]
+    nsteps = chains.posterior.log_amplitude.values.shape[1]
+    fake_lc_path = f'{lc_folder_path}/{sn_name}_fnu.csv'
+    truth_path = None
+    if is_sim:
+        truth_path = f'{lc_folder_path}/{sn_name}_truth.csv'
+        truth = pd.read_csv(truth_path)
+        fmax_inject = 328.73734846133704 #FMax_realsn
+        fmax_eject = float(
+            glob.glob(f'{fit_folder_path}/{sn_name}_{band}_maxflux*')[0].split('maxflux_')[1].split('.npy')[0])
+    else:
+        fmax = np.max(fake_lc['fnu_microJy']) # TODO: THIS WILL CAUSE ISSUES...
+        print('ERRORRRR  i need fmax_inject AND fmax_eject')
+    warmupsteppath = f'{fit_folder_path}/{sn_name}_{band}_warmupsamples.npy'
+    fake_lc_path_smooth = f'{lc_folder_path}/{sn_name}_fnu_smooth.csv' # this will eventually interact w band
+    # open dfs, chains using paths
+    fake_lc_smooth = pd.read_csv(fake_lc_path_smooth)
+    fake_lc = pd.read_csv(fake_lc_path) 
+
+    ## markers and color palettes (needed for viz. of different chains)
+    markers = [':', '-', ':', '-', ':', '-.', '--', '-']
+    chain_lws = [2, 0.9, 2, 0.9, 3,2,1,0.5]
+    chain_alphas = [0.9, 0.9, 0.9, 0.9 ,0.7, 0.7, 0.7, 0.7]
+    chain_cols = ['#9CA3DB', '#9CA3DB', '#677DB7', '#677DB7', 'red', 'brown', 'cornflowerblue', 'black',]
+    truth_col = "#B52E2C" 
+    post_draws_col = '#191308'
+    color_dict = {'g': "MediumAquaMarine", 'r': "Crimson", 'i': "GoldenRod"}
+
+
+    ## skeleton of subplots
+    fig, axes = plt.subplot_mosaic("AABC;AADE;FFGH;IIJK;LLMN", figsize=(14,8))
+    plt.rcParams['font.family'] = 'sans-serif'
+    plt.rcParams['font.sans-serif'] = 'Avenir'
+
+
+    ## remove underlying axes to place text instead
+    for ax_name in ["B", "C", "D"]:
+        axes[ax_name].remove()
+    textstart_x = 0.52
+    fig.text(textstart_x, 0.96, f'fit: {fitname}')
+    fig.text(textstart_x, 0.75, f'init. method: {init_method}')
+    if is_sim:
+        ptable = params_table_truth_init(warmupsteppath, nchains, nsteps_warmup, truth_path)
+        fig.text(textstart_x, 0.82, f'\n{ptable}')
+        lnl_from_truth = lnl_from_sim(fake_lc, truth, max_flux = fmax_inject) #TODO: THIS IS CRUCIAL
+        fig.text(textstart_x, 0.72, f'lnl from truth: {lnl_from_truth:.3f}')
+        post_from_sim = posterior_from_sim_superphot(fake_lc, truth, max_flux=fmax_inject)[0]
+        fig.text(textstart_x, 0.69, f'posterior from truth: {post_from_sim:.3f}')
+    else:
+        ptable = params_table_truth_init(warmupsteppath, nchains, nsteps_warmup)
+        fig.text(textstart_x, 0.82, f'\n{ptable}')
+
+    ## axis lims and labels
+    axes["A"].set_xlabel('time (JD - 2018 Jan 01)')
+    axes["A"].set_ylabel(r'flux ($\mu$Jy)')
+    if xlim_for_draws is not None:
+        axes["A"].set_xlim(xlim_for_draws[0], xlim_for_draws[1])
+    for ax_name in ['L', 'M', 'N']:
+        axes[ax_name].set_xlabel('step #')
+    for ax_name in ['E', 'F', 'I', 'G', 'H', 'J', 'K']:
+        axes[ax_name].set_xticks([])
+        axes[ax_name].set_xticklabels([])
+    axes["F"].set_ylabel('lnl (numpyro)')
+    axes["I"].set_ylabel('lnl (saarah)')
+    axes["L"].set_ylabel('posterior (saarah)')
+
+
+    ## lnl and posterior plots
+    lnl_numpyro = np.sum(chains.log_likelihood.y.values, axis=2)
+    lnl_saarah = lnl_from_chains(fake_lc, chains, max_flux = fmax_eject)
+    post_saarah = posterior_from_chains_superphot(fake_lc, chains, max_flux = fmax_eject)
+    for i in range(nchains):
+        axes["F"].plot(np.arange(len(lnl_numpyro[i])), lnl_numpyro[i],alpha=chain_alphas[i],lw=chain_lws[i],ls=markers[i], c=chain_cols[i])
+        axes["I"].plot(np.arange(len(lnl_saarah[i])), lnl_saarah[i], alpha=chain_alphas[i],lw=chain_lws[i],ls=markers[i], c=chain_cols[i], label='chain '+str(i))
+        axes["L"].plot(np.arange(len(post_saarah[i])), post_saarah[i], alpha=chain_alphas[i],lw=chain_lws[i],ls=markers[i], c=chain_cols[i])
+
+    ## parameter step plots
+    param_names = ["log_amp", "beta", "log_gamma", "t0", "log_trise", "log_tfall", "log_extra_sigma"]
+    param_vals = [chains.posterior.log_amplitude, chains.posterior.beta, chains.posterior.log_gamma, chains.posterior.t0, chains.posterior.log_trise, chains.posterior.log_tfall, chains.posterior.log_extra_sigma]
+    for n, ax_name in enumerate(["G", "H", "J", "K", "M", "N", "E"]):
+        axes[ax_name].set_ylabel(param_names[n])
+        for i in range(nchains):
+            axes[ax_name].plot(np.arange(nsteps), param_vals[n][i].values, lw=chain_lws[i], ls=markers[i], c=chain_cols[i], alpha=chain_alphas[i])
+        if is_sim:
+            if param_names[n] == 'log_extra_sigma':
+                continue
+            elif param_names[n] not in truth.columns:
+                tru_val = np.log10(truth[param_names[n].split("_")[1]].values[0])
+                axes[ax_name].axhline(tru_val, c=truth_col, lw=5)
+            else:
+                tru_val = truth[param_names[n]].values[0]
+                if param_names[n] == 'beta':
+                    axes[ax_name].axhline(tru_val, c=truth_col, lw=5, label='true value')
+                else:
+                    axes[ax_name].axhline(tru_val, c=truth_col, lw=5)
+
+
+
+    ## one legend for all chain-based plots
+    lines_labels = [ax.get_legend_handles_labels() for ax in fig.axes]
+    lines, labels = [sum(lol, []) for lol in zip(*lines_labels)]
+    fig.legend(lines, labels, loc=(0.905,0.815))
+
+
+    ## posterior draws and data
+    if is_sim:
+        axes["A"].plot(fake_lc_smooth['jd']-jd0, fake_lc_smooth['fnu_microJy'], c=truth_col, ls='-', lw=5, label='simulated model')
+        ## posterior draws and data
+        axes["A"].errorbar(fake_lc['jd']- jd0, fake_lc['fnu_microJy'], yerr=fake_lc['fnu_microJy_unc'], fmt='o', color=color_dict[band], 
+                    label='noisy simulated data')
+    else:
+        axes["A"].errorbar(fake_lc['jd']- jd0, fake_lc['fnu_microJy'], yerr=fake_lc['fnu_microJy_unc'], fmt='o', color=color_dict[band], 
+                    label='data')
+    fits_to_plot = superphot_sim_fits(fake_lc, chains, fmax_eject)
+    for p in range(len(fits_to_plot[1])):
+        if p == 0:
+            axes["A"].plot(fits_to_plot[0], fits_to_plot[1][p], color=post_draws_col, ls='--', lw=1.2, alpha=0.3, label='fit model')
+        else:
+            axes["A"].plot(fits_to_plot[0], fits_to_plot[1][p], color=post_draws_col, ls='--', lw=1.2, alpha=0.3)
+    axes["A"].legend()
+
+    plt.tight_layout()
+
+    if save_fig:
+            fig.savefig(f"{fit_folder_path}/{sn_name}_fitsummary.png",
+                        dpi=900, transparent=False)
+
+    return
+
+
+# --- ---
+def mkdir_and_numpyro(sn, out_path, nwarmup, nsample, nchain, init_strat, model, randomkey, lc_path='bts_lcs/'):
+    bool_out = os.path.isdir(out_path)
+    if not bool_out:
+        print('time to make a new path')
+        os.mkdir(out_path)
+        print('made a new path')
+    
+    fit_gr_numpyro(sn, lc_path, out_path, nwarmup, nsample, nchain, 
+                   init_strat, model, randomkey=randomkey)
+      
 def main():
 
     # Initialize argument parser
@@ -682,8 +1113,6 @@ def main():
                         help='number of chains for MCMC')
     parser.add_argument('init_strat', type=str, nargs='?', default=None,
                         help='initialization strategy for MCMC')
-    #parser.add_argument('init_values', type=dict, nargs='?', default=None,
-    #                    help='values for with initialize-to-value strategy')
 
     try:
         args = parser.parse_args()

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -227,7 +227,7 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
             init_strategy = init_to_mean
         elif init_strat == 'value':
             print('warning: init_to_value is hardcoded')
-            init_strategy = init_to_value(values = {"trise": 4, "tfall": 150, "Beta": 0, "scalar": 0, "gamma": 70/3})
+            init_strategy = init_to_value(values = {"trise": 4.0, "tfall": 150.0, "Beta": 0.0, "scalar": 0.0, "gamma": 23.33})
             #if init_values is not None:
             #    init_strategy = init_to_value(values = init_values)
             #else:

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -315,7 +315,7 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
                    dist.Normal(mu_switch, Y_unc_val),
                    obs=Y_observed_val)
 
-def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=4, init_strat='uniform', model=lc_model, init_values = None, randomkey=0):
+def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=4, init_strat='uniform', model=lc_model_superphot, init_values = None, randomkey=0):
     """
     Fit parametric model from Villar+19 [OR deSoto+24] to ZTF light curve
 

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -226,10 +226,12 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
         elif init_strat == 'mean':
             init_strategy = init_to_mean
         elif init_strat == 'value':
-            if init_values is not None:
-                init_strategy = init_to_value(values = init_values)
-            else:
-                print('could not use init_to_value, missing values')
+            print('warning: init_to_value is hardcoded')
+            init_strategy = init_to_value(values = {"trise": 4, "tfall": 150, "Beta": 0, "scalar": 0, "gamma": 70/3})
+            #if init_values is not None:
+            #    init_strategy = init_to_value(values = init_values)
+            #else:
+            #    print('could not use init_to_value, missing values')
         else:
             print('could not define initialization strategy based on input!')
 
@@ -523,8 +525,8 @@ def main():
                         help='number of chains for MCMC')
     parser.add_argument('init_strat', type=str, nargs='?', default=None,
                         help='initialization strategy for MCMC')
-    parser.add_argument('init_values', type=dict, nargs='?', default=None,
-                        help='values for with initialize-to-value strategy')
+    #parser.add_argument('init_values', type=dict, nargs='?', default=None,
+    #                    help='values for with initialize-to-value strategy')
 
     try:
         args = parser.parse_args()

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -61,6 +61,19 @@ def calc_sn_exp_both(t, A, B, t0, gamma, trise, tfall, offset):
                             (1 + jnp.exp(-(t - t0) / trise))))
     return f
 
+def y_model_superphot_plus(t, A, B, t0, gamma, trise, tfall, offset):
+    """eq. (1) from superphot_plus paper"""
+    f = jnp.where(t - t0 < gamma,
+                  
+                 ((A * (1 - (B * (t - t0)))) / (1 + jnp.exp(-(t - t0) / trise))) + offset,
+                 
+                  offset + (
+                      (A * (1 - (B * gamma))) *
+                            jnp.exp((gamma - (t - t0)) / tfall)
+                      /
+                            (1 + jnp.exp(-(t - t0) / trise))
+                           ))
+    return f
 
 def load_lc_df(sn, lc_path, min_num_obs=10):
     """
@@ -108,6 +121,102 @@ def load_lc_df(sn, lc_path, min_num_obs=10):
     lc_df_clean = lc_df.iloc[np.concatenate(keep_ind)]
     return lc_df_clean
 
+class TruncatedLogNormal(dist.Distribution):
+    def __init__(self, loc, scale, low, high, **kwargs):
+        # Log-normal parameters
+        self.loc = loc
+        self.scale = scale
+        self.low = low
+        self.high = high
+        super().__init__(**kwargs)
+
+    def sample(self, key, sample_shape=()):
+        # Sample from the log-normal distribution
+        log_normal_sample = dist.LogNormal(self.loc, self.scale).sample(key, sample_shape)
+        
+        # Apply truncation: enforce that the sample lies within [low, high]
+        return jnp.clip(log_normal_sample, self.low, self.high)
+
+    def log_prob(self, value):
+        # The log probability density function for truncated log-normal
+        # Apply truncation bounds in the log-prob calculation.
+        if jnp.any((value < self.low) | (value > self.high)):
+            return -jnp.inf  # Outside the bounds
+        
+        # Compute the log-probability of the log-normal distribution
+        log_prob = dist.LogNormal(self.loc, self.scale).log_prob(value)
+        return log_prob
+
+def villar_fit_constraint(x):
+    beta, gamma, tau_rise, tau_fall = x
+    return (
+        jnp.maximum(gamma - (1.0 - beta * tau_fall) / beta, 0.) +
+        jnp.maximum(jnp.exp(-gamma / tau_rise) * (1.0/beta - tau_rise - gamma) - tau_rise, 0.)
+    )
+
+def lc_model_superphot(t_val, Y_unc_val, Y_observed_val=None):
+    """
+    (Non-hierarchical) model for ZTF light curves, with priors based on superphot_plus/.../numpyro_sampler.py
+
+    Parameters
+    ----------
+    t_val : array-like
+        Time values at which the model is evaluated
+
+    Y_unc_val : array-like
+        Flux uncertainties at the observed times t_val
+
+    Y_observed_val : array-like (optional, default = None)
+        Flux observations at times t_val
+    """
+    # Superphot+ priors
+    ## Define priors based on superphot_plus/surveys/ztf.yaml (reference, works for r-band)
+    Amplitude = 10 ** numpyro.sample("logA", dist.TruncatedNormal(loc=0.0957,
+                                                                    scale=0.0575,
+                                                                    low=-0.3, high=0.5))
+    ### max_flux = jnp.max(Y_observed_val) # TODO REMOVE MAXFLUC FROM DATA
+
+    Beta = numpyro.sample("beta", dist.TruncatedNormal(loc=0.00833,
+                                                        scale=0.00385,
+                                                        low=0, high=0.03))
+
+    gamma = 10 ** numpyro.sample("log_gamma", dist.TruncatedNormal(loc=1.4258, scale=0.3079, low=0, high=3.5))
+
+    tFmax = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
+    t0 = numpyro.sample("t0", dist.TruncatedNormal(loc=tFmax - 17.878,
+                                                    scale=9.916,
+                                                    low=tFmax - 100, high=tFmax + 30))
+
+    trise = 10 ** numpyro.sample("log_trise", dist.TruncatedNormal(loc=0.6664, 
+                                                                    scale=0.4250, 
+                                                                    low=-2, high=4))
+
+    tfall = 10 ** numpyro.sample("log_tfall", dist.TruncatedNormal(loc=1.5261,
+                                                                    scale=0.3037,
+                                                                    low=0, high=4))
+    
+    extra_sigma = 10 ** numpyro.sample("log_extra_sigma", dist.TruncatedNormal(loc=-1.6629,
+                                                                                scale=0.3378,
+                                                                                low=-3, high=-0.8))
+    
+
+    constraint = villar_fit_constraint([Beta, gamma, trise, tfall])
+    numpyro.factor(
+        "vf_constraint",
+        -1000. * constraint
+    )
+
+    # Uncertainties (add extra_sigma in quad.)
+    sigma_tot = jnp.sqrt(Y_unc_val**2 + extra_sigma**2)
+
+    # Expected value of outcome - note max_flux now in amplitude
+    mu_switch = y_model_superphot_plus(t_val, Amplitude, Beta, t0, gamma, trise, tfall, 
+                                 0) # note, scalar = 0
+
+    # Sample!
+    numpyro.sample("y",
+                   dist.Normal(mu_switch, sigma_tot),
+                   obs=Y_observed_val)
 
 def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     """
@@ -126,8 +235,8 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     """
 
     # Define priors based on Villar+19
-    #trise = numpyro.sample("trise", dist.Uniform(low=0.01, high=50))  # dist.continuous.Uniform?
-    trise = numpyro.sample("trise", dist.TruncatedNormal(loc=6, scale=2, low=0))
+    trise = numpyro.sample("trise", dist.Uniform(low=0.01, high=50))  # dist.continuous.Uniform?
+    #trise = numpyro.sample("trise", dist.TruncatedNormal(loc=6, scale=2, low=0))
     tfall = numpyro.sample("tfall", dist.Uniform(low=1, high=300))
 
     Amp_Guess = jnp.max(Y_observed_val)
@@ -175,7 +284,7 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
 
 def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=4, init_strat='uniform', model=lc_model, init_values = None):
     """
-    Fit parametric model from Villar+19 to ZTF light curve
+    Fit parametric model from Villar+19 [OR deSoto+24] to ZTF light curve
 
     Parameters
     ----------
@@ -218,9 +327,13 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
         jd0 = 2458119.5  # 2018 Jan 01
         time_axis = (lc_df_thisfilt['jd'].values) - jd0
 
-        Y_observed = ((lc_df_thisfilt['fnu_microJy']).values)
+        Y_observed_orig = ((lc_df_thisfilt['fnu_microJy']).values)
+        Y_observed_max = jnp.max(Y_observed_orig)
+        print(f'scaling data by dividing by Y_obserbed_max: {Y_observed_max}. keep in mind when visualizing posterior draws!!!')
+        Y_observed = Y_observed_orig / Y_observed_max
 
-        Y_unc = ((lc_df_thisfilt['fnu_microJy_unc']).values)
+        Y_unc_orig = ((lc_df_thisfilt['fnu_microJy_unc']).values)
+        Y_unc = ((lc_df_thisfilt['fnu_microJy_unc']).values) / Y_observed_max
 
         if init_strat == 'uniform':
             init_strategy = init_to_uniform

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -75,6 +75,20 @@ def y_model_superphot_plus(t, A, B, t0, gamma, trise, tfall, offset):
                            ))
     return f
 
+def y_model_superphot_plus_logs(t, logA, B, t0, log_gamma, log_trise, log_tfall, offset):
+    """eq. (1) from superphot_plus paper"""
+    f = jnp.where(t - t0 < (10**log_gamma),
+                  
+                 (((10**logA) * (1 - (B * (t - t0)))) / (1 + jnp.exp(-(t - t0) / (10**log_trise)))) + offset,
+                 
+                  offset + (
+                      ((10**logA) * (1 - (B * (10**log_gamma)))) *
+                            jnp.exp(((10**log_gamma) - (t - t0)) / (10**log_tfall))
+                      /
+                            (1 + jnp.exp(-(t - t0) / (10**log_trise)))
+                           ))
+    return f
+
 def load_lc_df(sn, lc_path, min_num_obs=10):
     """
     Load ZTF light curve (LC) into a dataframe, with quality cuts
@@ -173,33 +187,50 @@ def lc_model_superphot(t_val, Y_unc_val, Y_observed_val=None):
     ## Define priors based on superphot_plus/surveys/ztf.yaml (reference, works for r-band)
     Amplitude = 10 ** numpyro.sample("logA", dist.TruncatedNormal(loc=0.0957,
                                                                     scale=0.0575,
-                                                                    low=-0.3, high=0.5))
+                                                                    low=-0.3, high=0.5, validate_args=False))
+    #logAmplitude = numpyro.sample("logA", dist.TruncatedNormal(loc=0.0957,
+    #                                                                scale=0.0575,
+    #                                                                low=-0.3, high=0.5))
     ### max_flux = jnp.max(Y_observed_val) # TODO REMOVE MAXFLUC FROM DATA
 
     Beta = numpyro.sample("beta", dist.TruncatedNormal(loc=0.00833,
                                                         scale=0.00385,
-                                                        low=0, high=0.03))
+                                                        low=0, high=0.03, validate_args=False))
 
-    gamma = 10 ** numpyro.sample("log_gamma", dist.TruncatedNormal(loc=1.4258, scale=0.3079, low=0, high=3.5))
+    gamma = 10 ** numpyro.sample("log_gamma", dist.TruncatedNormal(loc=1.4258, scale=0.3079, low=0, high=3.5, validate_args=False))
+    #loggamma = numpyro.sample("log_gamma", dist.TruncatedNormal(loc=1.4258, scale=0.3079, low=0, high=3.5))
 
     tFmax = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
     t0 = numpyro.sample("t0", dist.TruncatedNormal(loc=tFmax - 17.878,
                                                     scale=9.916,
-                                                    low=tFmax - 100, high=tFmax + 30))
+                                                    low=tFmax - 100, high=tFmax + 30, validate_args=False))
 
     trise = 10 ** numpyro.sample("log_trise", dist.TruncatedNormal(loc=0.6664, 
                                                                     scale=0.4250, 
-                                                                    low=-2, high=4))
+                                                                    low=-2, high=4, validate_args=False))
+    #logtrise = numpyro.sample("log_trise", dist.TruncatedNormal(loc=0.6664, 
+    #                                                                scale=0.4250, 
+    #                                                                low=-2, high=4))
 
     tfall = 10 ** numpyro.sample("log_tfall", dist.TruncatedNormal(loc=1.5261,
                                                                     scale=0.3037,
-                                                                    low=0, high=4))
+                                                                    low=0, high=4, validate_args=False))
+    #logtfall = numpyro.sample("log_tfall", dist.TruncatedNormal(loc=1.5261,
+    #                                                                scale=0.3037,
+    #                                                                low=0, high=4))
     
+    # NO EXTRA SIGMA????
     extra_sigma = 10 ** numpyro.sample("log_extra_sigma", dist.TruncatedNormal(loc=-1.6629,
                                                                                 scale=0.3378,
-                                                                                low=-3, high=-0.8))
+                                                                                low=-3, high=-0.8, validate_args=False))
     
+    # TEST ADDING SCALAR (although not in superphot+ models) 
+    #sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
+    #scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,
+    #                                                       low=-2 * sigma_est,
+    #                                                       high=2 * sigma_est))
 
+    # TODO: NEW LC_MODEL_LOG FITTING W CONSTRAINT
     constraint = villar_fit_constraint([Beta, gamma, trise, tfall])
     numpyro.factor(
         "vf_constraint",
@@ -211,7 +242,9 @@ def lc_model_superphot(t_val, Y_unc_val, Y_observed_val=None):
 
     # Expected value of outcome - note max_flux now in amplitude
     mu_switch = y_model_superphot_plus(t_val, Amplitude, Beta, t0, gamma, trise, tfall, 
-                                 0) # note, scalar = 0
+                                 0)#,scalar)
+    #mu_switch = y_model_superphot_plus_logs(t_val, logAmplitude, Beta, t0, loggamma, logtrise, logtfall, 
+    #                             0)#,scalar)
 
     # Sample!
     numpyro.sample("y",
@@ -282,7 +315,7 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
                    dist.Normal(mu_switch, Y_unc_val),
                    obs=Y_observed_val)
 
-def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=4, init_strat='uniform', model=lc_model, init_values = None):
+def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, num_chains=4, init_strat='uniform', model=lc_model, init_values = None, randomkey=0):
     """
     Fit parametric model from Villar+19 [OR deSoto+24] to ZTF light curve
 
@@ -339,13 +372,18 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
             init_strategy = init_to_uniform
         elif init_strat == 'mean':
             init_strategy = init_to_mean
-        elif init_strat == 'value':
+        elif init_strat == 'value':# & (model == lc_model_superphot):
             print('warning: init_to_value is hardcoded')
             Amp_Guess = jnp.max(Y_observed)
             # gaussian t0 center
-            t0_uniform_prior_center = jnp.array(time_axis)[jnp.argmax(Y_observed)] - 10
-            init_strategy = init_to_value(values = {"trise": 4.0, "tfall": 150.0, "Beta": 0.0, "scalar": 0.0, "gamma": 23.33,
-                                                    "Amplitude": Amp_Guess, "t0": t0_uniform_prior_center})
+            #t0_uniform_prior_center = jnp.array(time_axis)[jnp.argmax(Y_observed)] - 10
+
+            ## VALUES FOR ZTF18abxoqkd; superphot+ translated but linear
+            #init_strategy = init_to_value(values = {"logA": 1.0573, "beta": 0.0022, "t0": 1408.2236, "log_gamma": 10.5832,
+            #                                        "log_trise": 2.3345, "log_tfall": 17.1516, "scalar": 0})
+            # logged vers.
+            init_strategy = init_to_value(values = {"logA": np.log10(1.0573), "beta": 0.0022, "t0": 1408.2236, "log_gamma": np.log10(10.5832),
+                                                    "log_trise": np.log10(2.3345), "log_tfall": np.log10(17.1516), "scalar": 0})
             #if init_values is not None:
             #    init_strategy = init_to_value(values = init_values)
             #else:
@@ -358,13 +396,14 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
             num_warmup=num_warmup,
             num_samples=num_samples,
             num_chains=num_chains,
-            progress_bar=True)
-        sampler.warmup(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
+            progress_bar=True,
+            chain_method="parallel")
+        sampler.warmup(jax.random.PRNGKey(randomkey), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
         warmup_samples = sampler.get_samples()
         np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
 
         # Draw samples from the posterior
-        sampler.run(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed)
+        sampler.run(jax.random.PRNGKey(randomkey), time_axis, Y_unc, Y_observed_val=Y_observed)
         samples = sampler.get_samples()
         np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
 

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -135,15 +135,15 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
         loc=Amp_Guess,
         scale=Amp_Guess / 10, low=0))
 
-    #Beta = numpyro.sample("Beta", dist.Uniform(low=-jnp.max(Y_observed_val) / 150, high=0))
-    uniformbeta_low = -jnp.max(Y_observed_val) / 150
-    Beta = numpyro.sample("Beta", dist.Normal(0, uniformbeta_low * (-0.3)))
+    Beta = numpyro.sample("Beta", dist.Uniform(low=-jnp.max(Y_observed_val) / 150, high=0))
+    #uniformbeta_low = -jnp.max(Y_observed_val) / 150
+    #Beta = numpyro.sample("Beta", dist.Normal(0, uniformbeta_low * (-0.3)))
 
-    #t0 = numpyro.sample("t0", dist.Uniform(
-    #    low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
-    #    high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
-    t0_uniform_prior_center = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
-    t0 = numpyro.sample("t0", dist.Normal(t0_uniform_prior_center - 10, 10))
+    t0 = numpyro.sample("t0", dist.Uniform(
+        low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
+        high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
+    #t0_uniform_prior_center = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
+    #t0 = numpyro.sample("t0", dist.Normal(t0_uniform_prior_center - 10, 10))
 
     sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
     scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -126,7 +126,8 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     """
 
     # Define priors based on Villar+19
-    trise = numpyro.sample("trise", dist.Uniform(low=0.01, high=50))  # dist.continuous.Uniform?
+    #trise = numpyro.sample("trise", dist.Uniform(low=0.01, high=50))  # dist.continuous.Uniform?
+    trise = numpyro.sample("trise", dist.TruncatedNormal(loc=6, scale=2, low=0))
     tfall = numpyro.sample("tfall", dist.Uniform(low=1, high=300))
 
     Amp_Guess = jnp.max(Y_observed_val)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -398,14 +398,14 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
             num_chains=num_chains,
             progress_bar=True,
             chain_method="parallel")
-        sampler.warmup(jax.random.PRNGKey(randomkey), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
-        warmup_samples = sampler.get_samples()
-        np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
+        #sampler.warmup(jax.random.PRNGKey(randomkey), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
+        #warmup_samples = sampler.get_samples()
+        #np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
 
         # Draw samples from the posterior
         sampler.run(jax.random.PRNGKey(randomkey), time_axis, Y_unc, Y_observed_val=Y_observed)
-        samples = sampler.get_samples()
-        np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
+        #samples = sampler.get_samples()
+        #np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
 
         # Save results
         data = az.from_numpyro(sampler)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -523,6 +523,8 @@ def main():
                         help='number of chains for MCMC')
     parser.add_argument('init_strat', type=str, nargs='?', default=None,
                         help='initialization strategy for MCMC')
+    parser.add_argument('init_values', type=dict, nargs='?', default=None,
+                        help='values for with initialize-to-value strategy')
 
     try:
         args = parser.parse_args()

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -8,7 +8,7 @@ import numpy as np
 import arviz as az
 import pandas as pd
 from scipy.stats import median_abs_deviation, truncnorm, rv_continuous, norm
-from numpyro.infer.initialization import init_to_mean, init_to_uniform, init_to_value
+from numpyro.infer.initialization import init_to_mean, init_to_uniform, init_to_value, init_to_feasible, init_to_median, init_to_sample
 
 import argparse
 import glob
@@ -120,7 +120,7 @@ def y_model_superphot(t, A, B, t0, gamma, trise, tfall, offset):
                            ))
     return f
 
-def load_lc_df(sn, lc_path, min_num_obs=10):
+def load_lc_df(sn, lc_path, min_num_obs=2):#10): #TODO: REVERT THIS
     """
     Load ZTF light curve (LC) into a dataframe, with quality cuts
 
@@ -310,11 +310,11 @@ def lc_model_superphot(t_obs, Y_unc, Y_obs=None, prior_vars='old'):
     #                                                       low=-2 * sigma_est, high=2 * sigma_est))
 
     # incorporate constraint from de Soto+24 Appendix B, this adds an arbitrary log prob. factor
-    constraint = villar_fit_constraint([beta, gamma, trise, tfall])
-    numpyro.factor(
-        "vf_constraint",
-        -1000. * jnp.max(constraint)
-    )
+    #constraint = villar_fit_constraint([beta, gamma, trise, tfall])
+    #numpyro.factor(
+    #    "vf_constraint",
+    #    -1000. * jnp.max(constraint)
+    #)
 
     # define uncertainties (add extra_sigma to observed uncertainties in quad.)
     sigma_tot = jnp.sqrt(Y_unc**2 + extra_sigma**2)
@@ -448,6 +448,9 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
         ## map input "init_strat" string to define strategy
         init_strat_dict = {'uniform' : init_to_uniform,
                        'mean': init_to_mean,
+                       'feasible': init_to_feasible,
+                       'median': init_to_median,
+                       'sample': init_to_sample,
                        'value': "need init. values"}
         this_init_strat = init_strat_dict[init_strat]
         ## specify initalization values (hardcoded for now, should only be used for testing)
@@ -461,7 +464,7 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
                                                     "t0": truths[3], "log_gamma": truths[2],
                                                     "log_trise": truths[4], 
                                                     "log_tfall": truths[5], "scalar": truths[6]})
-        elif init_strat not in ['uniform', 'mean', 'value']:
+        elif init_strat not in ['uniform', 'mean', 'value', 'feasible', 'median', 'sample']:
             print('could not define initialization strategy based on inputs!')
             return
 
@@ -938,7 +941,7 @@ def params_table_truth_init(warmup_path, nchains, nsteps_warmup, truth_path=None
     tab_logs.index = index_names # assign row names
     return tab_logs
 
-def summary_plot(sn_name, lc_folder_path, fit_folder_path, band, is_sim, init_method, nsteps_warmup, xlim_for_draws=None, save_fig=True, jd0 = 2458119.5):
+def summary_plot(sn_name, lc_folder_path, fit_folder_path, band, is_sim, init_method, nsteps_warmup, fmax_inject = None, xlim_for_draws=None, save_fig=True, jd0 = 2458119.5):
 
     #- run and fit a simulation
     #- as output w plots for a single run;
@@ -962,7 +965,10 @@ def summary_plot(sn_name, lc_folder_path, fit_folder_path, band, is_sim, init_me
     if is_sim:
         truth_path = f'{lc_folder_path}/{sn_name}_truth.csv'
         truth = pd.read_csv(truth_path)
-        fmax_inject = 328.73734846133704 #FMax_realsn
+        #fmax_inject = 328.73734846133704 #FMax_realsn
+        if fmax_inject is None:
+            fmax_inject = 328.73734846133704 #fmax of 'ZTF18abxoqkd', model SN for fakeSN{0-4}
+            print('warning; no `fmax_inject` provided; what SN maxflux did you use to make these fake SNe?')
         fmax_eject = float(
             glob.glob(f'{fit_folder_path}/{sn_name}_{band}_maxflux*')[0].split('maxflux_')[1].split('.npy')[0])
     else:
@@ -975,51 +981,54 @@ def summary_plot(sn_name, lc_folder_path, fit_folder_path, band, is_sim, init_me
     fake_lc = pd.read_csv(fake_lc_path) 
 
     ## markers and color palettes (needed for viz. of different chains)
-    markers = [':', '-', ':', '-', ':', '-.', '--', '-']
-    chain_lws = [2, 0.9, 2, 0.9, 3,2,1,0.5]
+    markers = [':', '-', ':', '-', ':', '-', ':', '-']
+    chain_lws = [2, 0.9, 2, 0.9, 2, 0.9, 2, 0.9]
     chain_alphas = [0.9, 0.9, 0.9, 0.9 ,0.7, 0.7, 0.7, 0.7]
-    chain_cols = ['#9CA3DB', '#9CA3DB', '#677DB7', '#677DB7', 'red', 'brown', 'cornflowerblue', 'black',]
+    chain_cols = ['#9CA3DB', '#9CA3DB', '#677DB7', '#677DB7', 'red', 'brown', 'cornflowerblue', 'black','goldenrod', 'hotpink', 'green']
     truth_col = "#B52E2C" 
     post_draws_col = '#191308'
     color_dict = {'g': "MediumAquaMarine", 'r': "Crimson", 'i': "GoldenRod"}
 
 
     ## skeleton of subplots
-    fig, axes = plt.subplot_mosaic("AABC;AADE;FFGH;IIJK;LLMN", figsize=(14,8))
+    # fig, axes = plt.subplot_mosaic("AABC;AADE;FFGH;IIJK;LLMN", figsize=(14,8)) # format without SNR plot
+    fig, axes = plt.subplot_mosaic("AABC;AADE;SSGH;FXJK;ILMN", figsize=(13,9)) # format with SNR plot
     plt.rcParams['font.family'] = 'sans-serif'
     plt.rcParams['font.sans-serif'] = 'Avenir'
 
 
     ## remove underlying axes to place text instead
-    for ax_name in ["B", "C", "D"]:
+    for ax_name in ["B", "C", "D", "X"]:
         axes[ax_name].remove()
     textstart_x = 0.52
     fig.text(textstart_x, 0.96, f'fit: {fitname}')
-    fig.text(textstart_x, 0.75, f'init. method: {init_method}')
+    fig.text(textstart_x, 0.77, f'init. method: {init_method}')
     if is_sim:
         ptable = params_table_truth_init(warmupsteppath, nchains, nsteps_warmup, truth_path)
         fig.text(textstart_x, 0.82, f'\n{ptable}')
         lnl_from_truth = lnl_from_sim(fake_lc, truth, max_flux = fmax_inject) #TODO: THIS IS CRUCIAL
-        fig.text(textstart_x, 0.72, f'lnl from truth: {lnl_from_truth:.3f}')
+        fig.text(0.3, 0.35, f'lnl from truth: {lnl_from_truth:.3f}')
         post_from_sim = posterior_from_sim_superphot(fake_lc, truth, max_flux=fmax_inject)[0]
-        fig.text(textstart_x, 0.69, f'posterior from truth: {post_from_sim:.3f}')
+        fig.text(0.3, 0.3, f'posterior from truth: {post_from_sim:.3f}')
     else:
         ptable = params_table_truth_init(warmupsteppath, nchains, nsteps_warmup)
         fig.text(textstart_x, 0.82, f'\n{ptable}')
 
     ## axis lims and labels
-    axes["A"].set_xlabel('time (JD - 2018 Jan 01)')
-    axes["A"].set_ylabel(r'flux ($\mu$Jy)')
+    axes["S"].set_xlabel('time (JD - 2018 Jan 01)')
     if xlim_for_draws is not None:
         axes["A"].set_xlim(xlim_for_draws[0], xlim_for_draws[1])
-    for ax_name in ['L', 'M', 'N']:
+        axes["S"].set_xlim(xlim_for_draws[0], xlim_for_draws[1])
+    for ax_name in ['L', 'M', 'N', 'I', 'L']:
         axes[ax_name].set_xlabel('step #')
-    for ax_name in ['E', 'F', 'I', 'G', 'H', 'J', 'K']:
+    for ax_name in ['E', 'F', 'G', 'H', 'J', 'K', 'S', 'X']:
         axes[ax_name].set_xticks([])
         axes[ax_name].set_xticklabels([])
+    axes["A"].set_ylabel(r'flux ($\mu$Jy)')
+    axes["S"].set_ylabel('SNR')
     axes["F"].set_ylabel('lnl (numpyro)')
     axes["I"].set_ylabel('lnl (saarah)')
-    axes["L"].set_ylabel('posterior (saarah)')
+    axes["L"].set_ylabel('posterior (saarah)') 
 
 
     ## lnl and posterior plots
@@ -1056,7 +1065,7 @@ def summary_plot(sn_name, lc_folder_path, fit_folder_path, band, is_sim, init_me
     ## one legend for all chain-based plots
     lines_labels = [ax.get_legend_handles_labels() for ax in fig.axes]
     lines, labels = [sum(lol, []) for lol in zip(*lines_labels)]
-    fig.legend(lines, labels, loc=(0.905,0.815))
+    fig.legend(lines, labels, loc=(0.901,0.815))
 
 
     ## posterior draws and data
@@ -1076,7 +1085,18 @@ def summary_plot(sn_name, lc_folder_path, fit_folder_path, band, is_sim, init_me
             axes["A"].plot(fits_to_plot[0], fits_to_plot[1][p], color=post_draws_col, ls='--', lw=1.2, alpha=0.3)
     axes["A"].legend()
 
+    ## SNR vs. time plot (baseline investigation)
+    SNR = (fake_lc.fnu_microJy - fake_lc.fnu_microJy_unc) / (np.sqrt(fake_lc.fnu_microJy_unc))
+    axes["S"].plot(fake_lc.jd - jd0, SNR, 's', ms=1, color='k')
+    snrplot_yspan = axes["S"].get_ylim()
+    axes["S"].axhspan(snrplot_yspan[1], 5, alpha=0.4, label = 'SNR > 5', color='darkseagreen')
+    axes["S"].axhspan(0, snrplot_yspan[0], alpha=0.4, label = 'SNR < 0', color='slategray')
+    axes["S"].legend()
+
+
     plt.tight_layout()
+    plt.subplots_adjust(hspace=0.20)
+    plt.subplots_adjust(wspace=0.30)
 
     if save_fig:
             fig.savefig(f"{fit_folder_path}/{sn_name}_fitsummary.png",

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -15,6 +15,10 @@ import glob
 import os
 
 
+
+numpyro.set_host_device_count(4)
+
+
 def y_model_villar19(t, A, B, t0, gamma, trise, tfall, offset):
     """
     Calculate the SN model from Villar+19. Incompatible with ztf priors from Superphot+

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -142,7 +142,7 @@ def lc_model(t_val, Y_unc_val, Y_observed_val=None):
     #    low=jnp.array(t_val)[jnp.argmax(Y_observed_val)] - 25,
     #    high=jnp.array(t_val)[jnp.argmax(Y_observed_val)] + 25))
     t0_uniform_prior_center = jnp.array(t_val)[jnp.argmax(Y_observed_val)]
-    t0 = numpyro.sample("t0", dist.Gaussian(mu=t0_uniform_prior_center - 10, sigma=10))
+    t0 = numpyro.sample("t0", dist.Normal(mu=t0_uniform_prior_center - 10, sigma=10))
 
     sigma_est = jnp.sqrt(jnp.mean(Y_unc_val ** 2))
     scalar = numpyro.sample("scalar", dist.TruncatedNormal(loc=0, scale=sigma_est,

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -239,14 +239,14 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
             num_samples=num_samples,
             num_chains=num_chains,
             progress_bar=True)
-        #sampler.warmup(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
-        #warmup_samples = sampler.get_samples()
-        #np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
+        sampler.warmup(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
+        warmup_samples = sampler.get_samples()
+        np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
 
         # Draw samples from the posterior
         sampler.run(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed)
-        #samples = sampler.get_samples()
-        #np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
+        samples = sampler.get_samples()
+        np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
 
         # Save results
         data = az.from_numpyro(sampler)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -239,14 +239,14 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
             num_samples=num_samples,
             num_chains=num_chains,
             progress_bar=True)
-        sampler.warmup(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
-        warmup_samples = sampler.get_samples()
-        np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
+        #sampler.warmup(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed, collect_warmup=True)
+        #warmup_samples = sampler.get_samples()
+        #np.save(f'{out_path}/{sn}_{filt}_warmupsamples.npy', warmup_samples)
 
         # Draw samples from the posterior
         sampler.run(jax.random.PRNGKey(0), time_axis, Y_unc, Y_observed_val=Y_observed)
-        samples = sampler.get_samples()
-        np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
+        #samples = sampler.get_samples()
+        #np.save(f'{out_path}/{sn}_{filt}_samples.npy', samples)
 
         # Save results
         data = az.from_numpyro(sampler)

--- a/analysis/fit_villar_numpyro.py
+++ b/analysis/fit_villar_numpyro.py
@@ -227,7 +227,11 @@ def fit_gr_numpyro(sn, lc_path, out_path, num_warmup=15000, num_samples=1000, nu
             init_strategy = init_to_mean
         elif init_strat == 'value':
             print('warning: init_to_value is hardcoded')
-            init_strategy = init_to_value(values = {"trise": 4.0, "tfall": 150.0, "Beta": 0.0, "scalar": 0.0, "gamma": 23.33})
+            Amp_Guess = jnp.max(Y_observed)
+            # gaussian t0 center
+            t0_uniform_prior_center = jnp.array(time_axis)[jnp.argmax(Y_observed)] - 10
+            init_strategy = init_to_value(values = {"trise": 4.0, "tfall": 150.0, "Beta": 0.0, "scalar": 0.0, "gamma": 23.33,
+                                                    "Amplitude": Amp_Guess, "t0": t0_uniform_prior_center})
             #if init_values is not None:
             #    init_strategy = init_to_value(values = init_values)
             #else:


### PR DESCRIPTION
This PR adds the numpyro-based fit_villar script, `fit_villar_numpyro.py`. A (non-hierarchical) numpyro model is defined by the function `fit_villar_numpyro.lc_model()`, and it closely mirrors the model in `fit_villar.fit_gr()`. It can be run from the terminal like this:

```
>>> from analysis.fit_villar_numpyro import fit_gr_numpyro
>>> fit_gr_numpyro(sn='ZTF18abauprj', lc_path='bts_lcs', out_path='bts_lcs/inference-terminal', num_warmup=1000, num_samples=1000, num_chains=2)
```
Note: you can modify the number of warmup steps, samples, and chains from the terminal.

 A draft of a hierarchical numpyro model is also defined by `fit_villar_numpyro.lc_model_hier_oneSN()`, but can't yet be run from the terminal.